### PR TITLE
A Diagram can get a context with any user data

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
   "scripts": {
+		"add-node": "node scripts/add-node.js",
     "build": "tsc",
     "build-cli": "npx webpack",
     "format": "prettier --write \"./**/*.(js|ts|json|md|css|less|scss)\"",

--- a/scripts/add-node.js
+++ b/scripts/add-node.js
@@ -4,7 +4,7 @@ const nodeName = process.argv[2];
 
 // Create Node file
 fs.writeFile(
-  __dirname + '/../server/nodes/' + nodeName + '.ts',
+  __dirname + '/../src/server/nodes/' + nodeName + '.ts',
   fs
     .readFileSync(__dirname + '/add-node.stub')
     .toString()
@@ -19,7 +19,7 @@ fs.writeFile(
 // Create Test file
 fs.writeFile(
   __dirname +
-    '/../../tests/unit/server/nodes/' +
+    '/../tests/Unit/server/nodes/' +
     nodeName +
     '.test.ts',
   fs

--- a/scripts/add-node.stub
+++ b/scripts/add-node.stub
@@ -1,4 +1,4 @@
-import Node from "../Node";
+import { Node } from "../Node";
 import NodeParameter from "../../NodeParameter";
 
 export default class NODE_NAME extends Node {

--- a/src/server/Context.ts
+++ b/src/server/Context.ts
@@ -1,0 +1,8 @@
+// the user is free to use any keys
+export class Context {
+	constructor(data: object) {
+		for (const [key, value] of Object.entries(data)) {
+			this[key] = value;
+		}		
+	}
+}

--- a/src/server/Diagram.ts
+++ b/src/server/Diagram.ts
@@ -1,3 +1,4 @@
+import { Context } from './Context';
 import { SerializedDiagram } from '../types/SerializedDiagram';
 import { Link } from './Link';
 import { Node } from './Node';
@@ -11,6 +12,11 @@ export default class Diagram {
     // id1: [d1, d2, ...]
   };
   history: Node[] = [];
+	context: Context = new Context({})
+
+	constructor(context?: Context) {
+		this.context = context ?? new Context({})
+	}
 
   static hydrate(data: SerializedDiagram, factory) {
     const instance = new this();
@@ -35,6 +41,14 @@ export default class Diagram {
 
     return instance;
   }
+
+	getContext(): Context {
+		return this.context
+	}
+
+	setContext(context: Context) {
+		this.context = context
+	}	
 
   async run() {
     for await (const node of this.executionOrder()) {

--- a/src/server/DiagramBuilder.ts
+++ b/src/server/DiagramBuilder.ts
@@ -1,9 +1,11 @@
+import { Context } from './Context';
 import Diagram from './Diagram';
 import { Node } from './Node';
 
 export class DiagramBuilder {
   currentNode?: Node;
   diagram?: Diagram;
+	diagramContext: Context;
 
   static begin() {
     return new this();
@@ -26,6 +28,11 @@ export class DiagramBuilder {
     return this.withParameters(parameterKeyValues);
   }
 
+	setContext(context: Context) {
+		this.diagramContext = context
+		return this
+	}
+
   withParameters(parameters: object) {
     for (const [name, value] of Object.entries(
       parameters,
@@ -44,6 +51,8 @@ export class DiagramBuilder {
   }
 
   protected getDiagram() {
-    return this.diagram ?? new Diagram();
+    return this.diagram ?? new Diagram(
+			this.diagramContext ?? new Context({})
+		);
   }
 }

--- a/src/server/NodeFactory.ts
+++ b/src/server/NodeFactory.ts
@@ -20,6 +20,7 @@ import Log from './nodes/Log';
 import Map from './nodes/Map';
 import OutputProvider from './nodes/OutputProvider';
 import RegExpFilter from './nodes/RegExpFilter';
+import ResolveContextFeatures from './nodes/ResolveContextFeatures';
 // import DeleteRepositories from './nodes/github/DeleteRepositories'
 // import Repositories from './nodes/github/Repositories'
 import Sample from './nodes/Sample';
@@ -54,6 +55,7 @@ export default class NodeFactory {
     Map,
     OutputProvider,
     RegExpFilter,
+		ResolveContextFeatures,
     // Repositories,
     Sample,
     Sleep,

--- a/src/server/nodes/ResolveContextFeatures.ts
+++ b/src/server/nodes/ResolveContextFeatures.ts
@@ -1,0 +1,38 @@
+import { Node } from "../Node";
+import NodeParameter from "../../NodeParameter";
+import { Feature } from "../../Feature";
+
+export default class ResolveContextFeatures extends Node {
+	constructor(options = {}) {
+		super({
+			// Defaults
+			name: 'ResolveContextFeatures',
+			summary: 'Resolve features from a context path',
+			category: 'Workflow',
+			defaultInPorts: [],
+			defaultOutPorts: ['Output'],			
+			// Explicitly configured
+			...options,
+		})
+	}
+
+	async run() {
+		const pathToFeatureData = this.getParameterValue('path_to_features')
+		const parts = pathToFeatureData.split('.');
+
+		const featureData = parts.reduce((carry, path) => {
+			return carry[path];
+		}, this.diagram.context)
+
+		this.output(
+			featureData.map(data => new Feature(data))
+		);
+	}		
+
+	getParameters() {
+		return [
+			...super.getParameters(),
+            NodeParameter.string('path_to_features').withDescription('you may use dot notated paths'),
+		]
+	}
+}

--- a/tests/Unit/server/Diagram.test.ts
+++ b/tests/Unit/server/Diagram.test.ts
@@ -1,0 +1,24 @@
+import Diagram from '../../../src/server/Diagram';
+import { Context } from '../../../src/server/Context';
+
+it('can create a Diagram without a explicit context', () => {
+	let diagram = new Diagram()
+	expect(diagram).toBeInstanceOf(Diagram)
+});
+
+it('may supply a context at creation', () => {
+	let diagram = new Diagram(new Context({foo: 'bar'}))
+
+	expect(diagram).toBeInstanceOf(Diagram)
+	expect(diagram.context).toBeInstanceOf(Context)
+	expect(diagram.context['foo']).toBe('bar')
+});
+
+it('may supply a context at a later stage', () => {
+	let diagram = new Diagram()
+	diagram.setContext(new Context({foo: 'bar'}))
+
+	expect(diagram).toBeInstanceOf(Diagram)
+	expect(diagram.context).toBeInstanceOf(Context)
+	expect(diagram.context['foo']).toBe('bar')	
+});

--- a/tests/Unit/server/NodeTester.ts
+++ b/tests/Unit/server/NodeTester.ts
@@ -5,9 +5,11 @@ import OutputProvider from '../../../src/server/nodes/OutputProvider';
 import { Server } from '../../../src/server/Server';
 import { Port } from '../../../src/server/Port';
 import { Node } from '../../../src/server/Node';
+import { Context } from '../../../src/server/Context';
 
 export class NodeTester {
   diagram: Diagram;
+	diagramContext: Context;
   runResult: Diagram;
   nodeClass;
   parameterKeyValues: {};
@@ -43,6 +45,11 @@ export class NodeTester {
   hasParameters(parameterKeyValues) {
     return this.parameters(parameterKeyValues);
   }
+
+	diagramHasContext(contextData) {
+		this.diagramContext = new Context(contextData)
+		return this
+	}
 
   and() {
     return this;
@@ -115,7 +122,7 @@ export class NodeTester {
 
   protected setupDiagram() {
     this.diagram = DiagramBuilder.begin()
-
+			.setContext(this.diagramContext ?? new Context({}))
       .add(
         OutputProvider,
         {

--- a/tests/Unit/server/nodes/ResolveContextFeatures.test.ts
+++ b/tests/Unit/server/nodes/ResolveContextFeatures.test.ts
@@ -1,0 +1,34 @@
+import ResolveContextFeatures from '../../../../src/server/nodes/ResolveContextFeatures'
+import { when } from "../NodeTester";
+
+it('can resolve values from context', async () => {
+    await when(ResolveContextFeatures)
+		.hasParameters({
+			'path_to_features': 'phones'
+		})
+		.and().diagramHasContext({
+			phones: [
+				{product: 'iphone', price: 199},
+				{product: 'samsung', price: 119},
+				{product: 'nokia', price: 15},
+			]
+		})
+		.assertOutput([
+			{product: 'iphone', price: 199},
+			{product: 'samsung', price: 119},
+			{product: 'nokia', price: 15},			
+		])
+		.finish()
+});
+
+it('can resolve from a nested context', async () => {
+	await when(ResolveContextFeatures)
+	.hasParameters({
+		'path_to_features': 'a.b.c'
+	})
+	.and().diagramHasContext({
+		a: {b: {c: [1,2,3]}}
+	})
+	.assertOutput([1,2,3])
+	.finish()
+});


### PR DESCRIPTION
### What

We can give a Diagram a context with prepared features, settings or anything we want to make globally available.

```
let context = new Context({
  data: {
    models: {
      pricelists: [{price: 10}, {price: 5}, {price: 199}]
    }
  }
})

diagram.setContext(context).run()
```

### Example usage in a Node
ResolveContextFeautres Node may be used to read from context and output features. In this case it will output three Features.
![image](https://user-images.githubusercontent.com/3457668/125815380-52d3d5df-8597-4b8a-bf44-eaf21adeb446.png)

![image](https://user-images.githubusercontent.com/3457668/125815197-0d3ad418-a68e-4339-8897-2f0a39627e50.png)
