### PR TITLE
Postinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ See also [data-story-org/gui](https://github.com/data-story-org/gui)
 ## Development
 
 ### Installation
+
 ```
 yarn
 # Build web files
@@ -14,12 +15,17 @@ npx webpack
 ```
 
 ### Tests
+
 Run tests with
+
 ```
 yarn test --watch
 ```
+
 ### Add node
+
 You may run the following command
+
 ```
 yarn add-node YourNodeName
 ```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:quiet:fix": "eslint src --quiet --fix --ext .js,.ts",
     "test": "jest --config jest.config.js",
     "prepare": "npm run build",
+    "postinstall": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
     "version": "npm run format && git add -A src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,12 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true /* Generates corresponding '.d.ts' file. */,
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./lib" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
+    "composite": true /* Enable project compilation */,
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
@@ -69,6 +69,6 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src"],
+  "include": ["src", "package.json"],
   "exclude": ["node_modules", "**/__tests__/*"]
 }


### PR DESCRIPTION
Will fix error when lib/ folder can't be created when core is added as dependency.