### PR TITLE
Implement repeatables

### DIFF
--- a/src/NodeParameter.ts
+++ b/src/NodeParameter.ts
@@ -1,3 +1,18 @@
+type Repeatables = {
+  [k: number]: any;
+};
+
+type RepeatableConverter = (
+  repeatables: Repeatables,
+) => any[];
+
+// Return an array of values by default
+const defaultRepeatableConverter = (
+  repeatables: Repeatables,
+) => {
+  return Object.values(repeatables);
+};
+
 export default class NodeParameter {
   name: string;
   description = '';
@@ -5,6 +20,8 @@ export default class NodeParameter {
   placeholder?: string;
   value: any = '';
   options?: string[];
+  isRepeatable = false;
+  repeatableConverter: () => any;
 
   constructor(name: string) {
     this.name = name;
@@ -60,6 +77,18 @@ export default class NodeParameter {
 
   withDescription(description: string) {
     this.description = description;
+    return this;
+  }
+
+  repeatable(
+    converter: RepeatableConverter = defaultRepeatableConverter,
+  ) {
+    this.value = [this.value];
+    this.isRepeatable = true;
+    this.repeatableConverter = function () {
+      this.value = converter(this.value);
+    };
+
     return this;
   }
 }

--- a/src/server/nodes/RemoveAttributes.ts
+++ b/src/server/nodes/RemoveAttributes.ts
@@ -19,7 +19,7 @@ export default class RemoveAttributes extends Node {
   async run() {
     const toRemove = this.getParameterValue(
       'attributes to remove',
-    ).split(',');
+    );
 
     this.output(
       this.input().map((feature) => {
@@ -35,21 +35,17 @@ export default class RemoveAttributes extends Node {
             {},
           );
 
-        // if (Object.keys(filtered).length === 0) {
-        //   return undefined;
-        // }
         return new Feature(filtered);
       }),
-      // .filter((feature) => feature !== undefined),
     );
   }
 
   getDefaultParameters() {
     return [
       ...super.getDefaultParameters(),
-      NodeParameter.string(
-        'attributes to remove',
-      ).withValue('resource,name'),
+      NodeParameter.string('attributes to remove')
+        .withValue('resource')
+        .repeatable(),
     ];
   }
 }

--- a/tests/Unit/server/nodes/RemoveAttributes.test.ts
+++ b/tests/Unit/server/nodes/RemoveAttributes.test.ts
@@ -13,7 +13,7 @@ describe('RemoveAttributes node', () => {
       ])
       .and()
       .parameters({
-        'attributes to remove': 'resource,os',
+        'attributes to remove': ['resource', 'os'],
       })
       .assertOutput([
         {},
@@ -39,7 +39,10 @@ describe('RemoveAttributes node', () => {
       ])
       .and()
       .parameters({
-        'attributes to remove': `${attribute1},${attribute2}`,
+        'attributes to remove': [
+          `${attribute1}`,
+          `${attribute2}`,
+        ],
       })
       .assertOutput([{}, {}, wantedFeature])
       .finish();


### PR DESCRIPTION
# Info

NodeParameter now supports new method &#x2014; repeatable.


## Repeatable method

It can accept one argument &#x2014; converter callback, which is meant to convert object of such structure

```js
{
  1: 'resource',
  2: 'name',
  3: 'os',
  ...,
  n: 'another value'
}
```

into the structure we want to use in our Node. By default, if no converter passed, node parameter will transform value given into an Array

```js
["resource", "name", "os", ..., "another value"]
```

But if we for somewhat reasons wanted to convert object of values into a string of comma-separated values we can pass such an converter to repeatable method

```js
NodeParameter.string('attributes to remove')
    .withValue('resource')
    .repeatable(obj => {
      Object.values(obj).join()
    }),
```

So now data from the fronted will look like this

```js
"resource,name,os,...,another value"
```

    undefined


## Values

default given value will be automatically converted to a list with this default value, so for

```js
NodeParameter.string('attributes to remove')
    .withValue('resource')
    .repeatable()
```

default value will be

```js
['resource']
```

 


## Frontend
![Screenshot 2021-07-29 at 18-10-29 DataStory](https://user-images.githubusercontent.com/49302467/127522159-b2881551-1a30-4a07-80f1-2bd2a6e74fb8.png)
