### PR TITLE
Rows functonality, RenameAttributes Node

### DIFF
--- a/src/NodeParameter.ts
+++ b/src/NodeParameter.ts
@@ -19,6 +19,7 @@ export default class NodeParameter {
   fieldType = 'String_';
   placeholder?: string;
   value: any = '';
+  defaultValue: any = '';
   options?: string[];
   isRepeatable = false;
   repeatableConverter: () => any;
@@ -91,7 +92,9 @@ export default class NodeParameter {
   repeatable(
     converter: RepeatableConverter = defaultRepeatableConverter,
   ) {
+    this.defaultValue = this.value;
     this.value = [this.value];
+
     this.isRepeatable = true;
     this.repeatableConverter = function () {
       this.value = converter(this.value);

--- a/src/NodeParameter.ts
+++ b/src/NodeParameter.ts
@@ -4,7 +4,7 @@ type Repeatables = {
 
 type RepeatableConverter = (
   repeatables: Repeatables,
-) => any[];
+) => any;
 
 // Return an array of values by default
 const defaultRepeatableConverter = (
@@ -23,12 +23,13 @@ export default class NodeParameter {
   isRepeatable = false;
   repeatableConverter: () => any;
 
-  constructor(name: string) {
+  constructor(name: string, value: any = '') {
     this.name = name;
+    this.value = value;
   }
 
-  static make(name: string) {
-    return new this(name);
+  static make(name: string, value: any = '') {
+    return new this(name, value);
   }
 
   static json(name: string) {
@@ -53,6 +54,13 @@ export default class NodeParameter {
 
   static textarea(name: string) {
     return this.make(name).withFieldType('Textarea');
+  }
+
+  static row(name: string, params: NodeParameter[]) {
+    const value = Object.fromEntries(
+      params.map((p) => [p.name, p]),
+    );
+    return this.make(name, value).withFieldType('Row');
   }
 
   withFieldType(type: string) {

--- a/src/server/Node.ts
+++ b/src/server/Node.ts
@@ -151,7 +151,7 @@ export abstract class Node {
   protected getParameterValue(
     name: string,
     feature: Feature = null,
-  ): string {
+  ): any {
     const value = this.getParameter(name).value;
 
     if (!feature) return value;

--- a/src/server/NodeFactory.ts
+++ b/src/server/NodeFactory.ts
@@ -28,6 +28,7 @@ import Sort from './nodes/Sort';
 import Sleep from './nodes/Sleep';
 import ThrowError from './nodes/ThrowError';
 import RemoveAttributes from './nodes/RemoveAttributes';
+import RenameAttributes from './nodes/RenameAttributes';
 
 import { SerializedNode } from '../types/SerializedNode';
 import { ApiNodeFactory } from './nodes/factories/ApiNodeFactory';
@@ -60,6 +61,7 @@ export default class NodeFactory {
     RegExpFilter,
     ResolveContextFeatures,
     RemoveAttributes,
+    RenameAttributes,
     Sample,
     Sleep,
     Sort,

--- a/src/server/nodes/RenameAttributes.ts
+++ b/src/server/nodes/RenameAttributes.ts
@@ -33,8 +33,6 @@ export default class RenameAttributes extends Node {
       'Attributes to rename',
     );
 
-    // const values = Object.values(toRename);
-
     // Convert our results from frontend into
     // an extremely fast and usefull map in format of
     // previousAttributeName => nextAttributeName

--- a/src/server/nodes/RenameAttributes.ts
+++ b/src/server/nodes/RenameAttributes.ts
@@ -1,0 +1,93 @@
+import NodeParameter from '../../NodeParameter';
+import { Feature } from '../../Feature';
+import { Node } from '../Node';
+
+const clone = (obj) => Object.assign({}, obj);
+
+const renameKey = (object, key, newKey) => {
+  const clonedObj = clone(object);
+  const targetKey = clonedObj[key];
+
+  delete clonedObj[key];
+  clonedObj[newKey] = targetKey;
+
+  return clonedObj;
+};
+
+export default class RenameAttributes extends Node {
+  constructor(options = {}) {
+    super({
+      // Defaults
+      name: 'RenameAttributes',
+      summary: 'Renames configured attributes',
+      category: 'Workflow',
+      defaultInPorts: ['Input'],
+      defaultOutPorts: ['Output'],
+      // Explicitly configured
+      ...options,
+    });
+  }
+
+  async run() {
+    const toRename = this.getParameterValue(
+      'Attributes to rename',
+    );
+
+    this.output(
+      this.input().map((feature) => {
+        const { original } = feature;
+
+        let filtered = original;
+
+        Object.keys(filtered).forEach((key) => {
+          toRename.has(key)
+            ? (filtered = renameKey(
+                filtered,
+                key,
+                toRename.get(key),
+              ))
+            : null;
+        });
+
+        return new Feature(filtered);
+      }),
+    );
+  }
+
+  getDefaultParameters() {
+    return [
+      ...super.getDefaultParameters(),
+      NodeParameter.row('Attributes to rename', [
+        NodeParameter.string('input').withValue('resource'),
+        NodeParameter.string('output').withValue(
+          'globarlResource',
+        ),
+      ]).repeatable((result) => {
+        const values = Object.values(result);
+
+        // Convert our result object from frontend into
+        // an extremely fast and usefull map in format of
+        // previousAttributeName => nextAttributeName
+        //
+        // Map {
+        //     "resource" => "globalResource",
+        //     'globalId' => "GLOBALID",
+        //     ...,
+        //     "n"        => "N"
+        // }
+        const renameMap = new Map();
+
+        values.map((result) => {
+          Object.values(result).forEach((param) => {
+            renameMap.set(
+              param['value']['input'],
+              param['value']['output'],
+            );
+          });
+        });
+
+        return renameMap;
+      }),
+    ];
+  }
+}

--- a/src/server/nodes/RenameAttributes.ts
+++ b/src/server/nodes/RenameAttributes.ts
@@ -33,6 +33,27 @@ export default class RenameAttributes extends Node {
       'Attributes to rename',
     );
 
+    // const values = Object.values(toRename);
+
+    // Convert our results from frontend into
+    // an extremely fast and usefull map in format of
+    // previousAttributeName => nextAttributeName
+    //
+    // Map {
+    //     "resource" => "globalResource",
+    //     'globalId' => "GLOBALID",
+    //     ...,
+    //     "n"        => "N"
+    // }
+    const renameMap = new Map();
+
+    toRename.map((result) => {
+      renameMap.set(
+        result['input']['value'],
+        result['output']['value'],
+      );
+    });
+
     this.output(
       this.input().map((feature) => {
         const { original } = feature;
@@ -40,11 +61,11 @@ export default class RenameAttributes extends Node {
         let filtered = original;
 
         Object.keys(filtered).forEach((key) => {
-          toRename.has(key)
+          renameMap.has(key)
             ? (filtered = renameKey(
                 filtered,
                 key,
-                toRename.get(key),
+                renameMap.get(key),
               ))
             : null;
         });
@@ -58,36 +79,13 @@ export default class RenameAttributes extends Node {
     return [
       ...super.getDefaultParameters(),
       NodeParameter.row('Attributes to rename', [
-        NodeParameter.string('input').withValue('resource'),
-        NodeParameter.string('output').withValue(
-          'globarlResource',
+        NodeParameter.string('input').withValue(
+          'Attribute',
         ),
-      ]).repeatable((result) => {
-        const values = Object.values(result);
-
-        // Convert our result object from frontend into
-        // an extremely fast and usefull map in format of
-        // previousAttributeName => nextAttributeName
-        //
-        // Map {
-        //     "resource" => "globalResource",
-        //     'globalId' => "GLOBALID",
-        //     ...,
-        //     "n"        => "N"
-        // }
-        const renameMap = new Map();
-
-        values.map((result) => {
-          Object.values(result).forEach((param) => {
-            renameMap.set(
-              param['value']['input'],
-              param['value']['output'],
-            );
-          });
-        });
-
-        return renameMap;
-      }),
+        NodeParameter.string('output').withValue(
+          'New name',
+        ),
+      ]).repeatable(),
     ];
   }
 }

--- a/tests/Unit/server/nodes/RenameAttributes.test.ts
+++ b/tests/Unit/server/nodes/RenameAttributes.test.ts
@@ -16,11 +16,20 @@ describe('RenameAttributes node', () => {
       ])
       .and()
       .parameters({
-        'Attributes to rename': new Map([
-          ['globalID', 'GLOBALID'],
-          ['PSTLCITY', 'CITY'],
-          ['resource', 'RESOURCE'],
-        ]),
+        'Attributes to rename': [
+          {
+            input: { value: 'globalID' },
+            output: { value: 'GLOBALID' },
+          },
+          {
+            input: { value: 'PSTLCITY' },
+            output: { value: 'CITY' },
+          },
+          {
+            input: { value: 'resource' },
+            output: { value: 'RESOURCE' },
+          },
+        ],
       })
       .assertOutput([
         { GLOBALID: id },

--- a/tests/Unit/server/nodes/RenameAttributes.test.ts
+++ b/tests/Unit/server/nodes/RenameAttributes.test.ts
@@ -1,0 +1,32 @@
+import RenameAttributes from '../../../../src/server/nodes/RenameAttributes';
+import { when } from '../NodeTester';
+import { generateRandomString } from '../../../helpers';
+
+describe('RenameAttributes node', () => {
+  it('Renames attributes from given input', async () => {
+    const id = generateRandomString();
+    const city = generateRandomString();
+    const resource = generateRandomString();
+
+    await when(RenameAttributes)
+      .hasInput([
+        { globalID: id },
+        { PSTLCITY: city },
+        { resource: resource },
+      ])
+      .and()
+      .parameters({
+        'Attributes to rename': new Map([
+          ['globalID', 'GLOBALID'],
+          ['PSTLCITY', 'CITY'],
+          ['resource', 'RESOURCE'],
+        ]),
+      })
+      .assertOutput([
+        { GLOBALID: id },
+        { CITY: city },
+        { RESOURCE: resource },
+      ])
+      .finish();
+  });
+});


### PR DESCRIPTION
# Updates


## Row functionality

For easier creating of rows, introduced new row fieldType and corresponding method for it&rsquo;s creation. Example of creating repeatable rows:

```js

NodeParameter.row('Attributes to rename', [
    NodeParameter.string('input').withValue(
        'Attribute',
    ),
    NodeParameter.string('output').withValue(
        'New name',
    ),
]).repeatable(),
```

so it basic look is

```js
row('name', [ list of nodes ]).repeatable()
```


## RenameAttributes

New node that uses rows for renaming attributes


## UI showcase
![image](https://user-images.githubusercontent.com/49302467/127710464-221141b4-b186-4f1a-b1c7-2c4f429c1a46.png)
![image](https://user-images.githubusercontent.com/49302467/127710621-3b8f2402-ff16-4eb5-be9f-f9b89124fd6b.png)
![image](https://user-images.githubusercontent.com/49302467/127710646-e3ad62c0-e14b-4793-9928-6c8b6737a8ce.png)


