### PR TITLE
Fix error when bundling gui

### DIFF
--- a/src/server/nodes/Inspect.ts
+++ b/src/server/nodes/Inspect.ts
@@ -1,8 +1,6 @@
 import { Node } from '../Node';
 
 export default class Inspect extends Node {
-  public features: any[];
-
   constructor(options = {}) {
     super({
       // Defaults


### PR DESCRIPTION
## Error
```ss
ERROR in /home/runner/work/gui/gui/node_modules/@data-story-org/core/src/server/nodes/Inspect.ts
4:9-17
[tsl] ERROR in /home/runner/work/gui/gui/node_modules/@data-story-org/core/src/server/nodes/Inspect.ts(4,10)
      TS2612: Property 'features' will overwrite the base property in 'Node'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.
```
## Solution 
Features property is already declared in Node class from which our Inspect
node extends, so there is no sense to re-declare the same property