### PR TITLE
Create defaults optimized for tinkering

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "eslint": "^7.32.0",
     "eslint-plugin-jest": "^24.4.0",
     "jest": "^26.6.0",
+    "prettier": "^2.3.2",
     "ts-jest": "^26.4.1",
     "ts-loader": "^9.2.4",
-    "typescript": "^4.0.3",
+    "typescript": "^4.3.5",
     "webpack": "^5.47.1",
-    "webpack-cli": "^4.7.2",
-    "prettier": "^2.3.2"
+    "webpack-cli": "^4.7.2"
   },
   "files": [
     "lib/**/*"

--- a/src/server/nodes/Create.ts
+++ b/src/server/nodes/Create.ts
@@ -7,7 +7,7 @@ export default class Create extends Node {
     super({
       // Defaults
       name: 'Create',
-      summary: 'Create a null feature',
+      summary: 'Create a feature',
       category: 'Workflow',
       defaultInPorts: [],
       defaultOutPorts: ['Output'],
@@ -54,7 +54,7 @@ export default class Create extends Node {
           'string',
         ])
         .withValue('object'),
-      NodeParameter.json('contents').withValue('{}'),
+      NodeParameter.json('contents').withValue('{"resource": "todos"}'),
     ];
   }
 }

--- a/tests/Unit/server/nodes/Create.test.ts
+++ b/tests/Unit/server/nodes/Create.test.ts
@@ -1,17 +1,10 @@
 import Create from '../../../../src/server/nodes/Create';
 import { when } from '../NodeTester';
 
-it('creates an empty object by default', async () => {
+it('creates an object with a single key by default', async () => {
   await when(Create)
     .hasDefaultParameters()
-    .assertOutput([{}])
-    .finish();
-});
-
-it('creates an empty object by default', async () => {
-  await when(Create)
-    .hasDefaultParameters()
-    .assertOutput([{}])
+    .assertOutput([{resource: 'todos'}])
     .finish();
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7508,7 +7508,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.0.3:
+typescript@^4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==


### PR DESCRIPTION
`{resource: "todos"}` instead of `{}`