### PR TITLE
Add support for filtering boolean and integer values

### DIFF
--- a/src/server/nodes/Filter.ts
+++ b/src/server/nodes/Filter.ts
@@ -35,7 +35,7 @@ export default class Filter extends Node {
       const { original } = feature;
 
       if (isAttributePrimitive) {
-        return original === port;
+        return original == port;
       }
 
       if (toMatchAgainst.length > 1) {
@@ -45,11 +45,11 @@ export default class Filter extends Node {
             : obj[path];
         }, original);
 
-        return data === port;
+        return String(data) == port;
       }
 
       return toMatchAgainst[0] in original
-        ? original[toMatchAgainst[0]] === port
+        ? String(original[toMatchAgainst[0]]) == port
         : false;
     };
 
@@ -78,13 +78,15 @@ export default class Filter extends Node {
         }, original);
 
         return !(data !== undefined
-          ? ports.includes(data)
+          ? ports.includes(String(data))
           : false);
       }
 
-      return !(toMatchAgainst[0] in original
-        ? ports.includes(original[toMatchAgainst[0]])
-        : false);
+      return toMatchAgainst[0] in original
+        ? !ports.includes(
+            String(original[toMatchAgainst[0]]),
+          )
+        : true;
     });
 
     this.output(unmatched, 'Unfiltered');


### PR DESCRIPTION
# Changes

Moved to less stricter equality checks with String conversion so it's possible to match on integer and boolean values

# Examples
# Filtering HTTPRequest against completed attribute
After configuring of such a story

![image](https://user-images.githubusercontent.com/49302467/129560143-00899c38-e384-46ca-b090-523391b504e9.png)
![image](https://user-images.githubusercontent.com/49302467/129560160-5e04a0c1-669e-4638-b7fe-6542439bc2ea.png)

And running it we can see that our features successfully divided into two groups.

![image](https://user-images.githubusercontent.com/49302467/129560211-04d8ec57-3181-43e4-a3af-0507fdaa2805.png)
![image](https://user-images.githubusercontent.com/49302467/129560285-8f9a5914-abac-474e-b0e9-e52fb0d43217.png)

# Filtering HTTPRequest against userId attribute
After running filter on features returned by HTTP-request we getting all features with userId we specified

![image](https://user-images.githubusercontent.com/49302467/129560843-e7b979c9-33ce-4174-8078-fd2c58304698.png)
![image](https://user-images.githubusercontent.com/49302467/129560880-06259a89-c8c7-4fa8-886b-9f0268bff5ea.png)
