### PR TITLE
Fix errors when editing loaded stories in gui

### DIFF
--- a/src/NodeParameter.ts
+++ b/src/NodeParameter.ts
@@ -7,7 +7,7 @@ type RepeatableConverter = (
 ) => any;
 
 // Return an array of values by default
-const defaultRepeatableConverter = (
+export const repeatableConverter: RepeatableConverter = (
   repeatables: Repeatables,
 ) => {
   return Object.values(repeatables);
@@ -35,7 +35,6 @@ export class NodeParameter {
   options?: string[];
   isRepeatable = false;
   wrappedPortType: SimpleFieldType = 'String_';
-  repeatableConverter: () => any;
 
   constructor(name: string, value: any = '') {
     this.name = name;
@@ -116,16 +115,11 @@ export class NodeParameter {
     return this;
   }
 
-  repeatable(
-    converter: RepeatableConverter = defaultRepeatableConverter,
-  ) {
+  repeatable() {
     this.defaultValue = this.value;
     this.value = [this.value];
 
     this.isRepeatable = true;
-    this.repeatableConverter = function () {
-      this.value = converter(this.value);
-    };
 
     return this;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,5 @@ export {
   groupBy,
   nonCircularJsonStringify,
 } from './utils';
+
+export { repeatableConverter } from './NodeParameter';

--- a/src/types/SerializedNode.ts
+++ b/src/types/SerializedNode.ts
@@ -1,3 +1,4 @@
+import { NodeParameter } from '../NodeParameter';
 import { SerializedPort } from './SerializedPort';
 
 export type SerializedNode = {
@@ -9,11 +10,7 @@ export type SerializedNode = {
   key?: string; // what?
   name: string;
   nodeReact: string; // what?
-  parameters: {
-    fieldType: string;
-    value: string;
-    name: string;
-  }[];
+  parameters: NodeParameter[];
   summary: string; // what?
   nodeType: string;
 };
@@ -31,11 +28,7 @@ export type SerializedReactNode = {
   key?: string; // what?
   name: string;
   nodeReact: string; // what?
-  parameters: {
-    fieldType: string;
-    value: string;
-    name: string;
-  }[];
+  parameters: NodeParameter[];
   summary: string; // what?
   nodeType: string;
   selected: unknown;


### PR DESCRIPTION
# Prerequisites
Since gui saved stories are being held in localstorage as JSON, which can't hold function inside that causes errors because we keep repeatableConverter on every parameter directly. Instead of that approach we will instead export repeatableConverter from core package, so saving and opening stories will work as expected.