### PR TITLE
Add support of testing dynamically created ports

### DIFF
--- a/src/server/DiagramBuilder.ts
+++ b/src/server/DiagramBuilder.ts
@@ -11,13 +11,22 @@ export class DiagramBuilder {
     return new this();
   }
 
-  add(nodeClass, parameterKeyValues = {}, config = {}) {
+  add(
+    nodeClass,
+    parameterKeyValues = {},
+    config = {},
+    dynamicPorts = null,
+  ) {
     const diagram = this.getDiagram();
 
     const node = new nodeClass({
       ...new nodeClass().serialize(),
       ...config,
     });
+
+    if (dynamicPorts != null) {
+      node.addDynamicPorts(dynamicPorts);
+    }
 
     diagram.addNode(node);
 

--- a/src/server/nodes/Filter.ts
+++ b/src/server/nodes/Filter.ts
@@ -82,7 +82,8 @@ export class Filter extends Node {
           : false);
       }
 
-      return toMatchAgainst[0] in original
+      return typeof original === 'object' &&
+        toMatchAgainst[0] in original
         ? !ports.includes(
             String(original[toMatchAgainst[0]]),
           )

--- a/tests/Unit/server/nodes/Filter.test.ts
+++ b/tests/Unit/server/nodes/Filter.test.ts
@@ -1,31 +1,115 @@
 import { Filter } from '../../../../src/server/nodes';
 import { when } from '../NodeTester';
+import { generateRandomString } from '../../../helpers';
+import sample from 'lodash/sample';
 
 describe('Filter node', () => {
   it('Filters based on given attribute and output ports', async () => {
     await when(Filter)
       .hasInput([
-        {
-          status: 'for-sale',
-        },
-        {
-          status: 'upcoming',
-        },
-        {
-          status: 'sold',
-        },
+        { status: 'for-sale' },
+        { status: 'upcoming' },
+        { status: 'sold' },
       ])
       .and()
       .parameters({
         'attribute to match against': 'status',
         'Output ports': ['upcoming', 'sold'],
       })
-      // .assertOutput({
-      //   Unfiltered: [{ status: 'for-sale' }],
-      // })
-      // Doesn't work because our test diagram don't create needed output ports
-      // .assertOutput([{ status: 'for-sale' }])
-      // .assertOutputCount(3)
+      .and()
+      .dynamicPorts(['upcoming', 'sold'])
+      .and()
+      .assertOutputs({
+        Unfiltered: [{ status: 'for-sale' }],
+        upcoming: [{ status: 'upcoming' }],
+        sold: [{ status: 'sold' }],
+      })
+      // .assertOutput([{ status: 'for-sale' }], 'Unfiltered')
+      .finish();
+  });
+
+  it('Filters with random arguments', async () => {
+    const randomValue1 = generateRandomString();
+    const randomValue2 = generateRandomString();
+    const needed = generateRandomString();
+
+    await when(Filter)
+      .hasInput([
+        { attrToMatch: randomValue1 },
+        { attrToMatch: needed },
+        { attrToMatch: randomValue2 },
+      ])
+      .and()
+      .parameters({
+        'attribute to match against': 'attrToMatch',
+        'Output ports': [needed],
+      })
+      .and()
+      .dynamicPorts([needed])
+      .and()
+      .assertOutputs({
+        Unfiltered: [
+          { attrToMatch: randomValue1 },
+          { attrToMatch: randomValue2 },
+        ],
+        [needed]: [{ attrToMatch: needed }],
+      })
+      .finish();
+  });
+
+  it('Filters with dot notated paths', async () => {
+    const randomValue1 = generateRandomString();
+    const randomValue2 = generateRandomString();
+    const needed = generateRandomString();
+
+    await when(Filter)
+      .hasInput([
+        { something: { attrToMatch: randomValue1 } },
+        { something: { attrToMatch: needed } },
+        { something: { attrToMatch: randomValue2 } },
+      ])
+      .and()
+      .parameters({
+        'attribute to match against':
+          'something.attrToMatch',
+        'Output ports': [needed],
+      })
+      .and()
+      .dynamicPorts([needed])
+      .and()
+      .assertOutputs({
+        Unfiltered: [
+          { something: { attrToMatch: randomValue1 } },
+          { something: { attrToMatch: randomValue2 } },
+        ],
+        [needed]: [{ something: { attrToMatch: needed } }],
+      })
+      .finish();
+  });
+
+  it('Filters with simple features', async () => {
+    const randomValue1 = generateRandomString();
+    const randomValue2 = generateRandomString();
+    const needed = generateRandomString();
+
+    await when(Filter)
+      .hasInput([randomValue1, needed, randomValue2])
+      .and()
+      .parameters({
+        'attribute to match against': sample([
+          'none',
+          '',
+          'attribute to match against',
+        ]),
+        'Output ports': [needed],
+      })
+      .and()
+      .dynamicPorts([needed])
+      .and()
+      .assertOutputs({
+        Unfiltered: [randomValue1, randomValue2],
+        [needed]: [needed],
+      })
       .finish();
   });
 });

--- a/tests/Unit/server/nodes/Filter.test.ts
+++ b/tests/Unit/server/nodes/Filter.test.ts
@@ -99,7 +99,7 @@ describe('Filter node', () => {
         'attribute to match against': sample([
           'none',
           '',
-          'attribute to match against',
+          'attribute to match',
         ]),
         'Output ports': [needed],
       })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,7 +50,7 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */


### PR DESCRIPTION
# Updates


## Dynamic ports testing

-   Added new functionality so testing nodes with dynamic port is possible now. Usage is pretty simple, just need to specify dynamic ports that would have been created on the gui, like here
```js
.parameters({
    ...,
    'Output ports': ['upcoming', 'sold'],
})
.and()
.dynamicPorts(['upcoming', 'sold'])
.assertOutputs({
    Unfiltered: [{ status: 'for-sale' }],
    upcoming: [{ status: 'upcoming' }],
    sold: [{ status: 'sold' }],
})
```

-   Made assertOutput more configurable so it&rsquo;s possible now to specify what port will be checked for the one output port

```js
...
.assertOutput([{ status: 'for-sale' }], 'Unfiltered')
...
```

-   Added/fixed a couple of types


## Filter tests

Added three more tests

1.  of filtering with random values
2.  of filtering with random values + dot notated paths
3.  of filtering with random values + simple features


## lodash usage

It&rsquo;s always better to import things from lodash library like here

```js
import cloneDeep from 'lodash/cloneDeep'
```

instead of importing of full library using asterix

```js
import * as _ from 'lodash'

_.cloneDeep
```

That will significantly reduce the bundle size