### PR TITLE
Fix bad execution order

### DIFF
--- a/src/server/Diagram.ts
+++ b/src/server/Diagram.ts
@@ -167,22 +167,22 @@ export class Diagram {
     );
 
     const linkLists = inPorts.map(
-      (port: any) => port.links,
+      (port: any) => port.getLinks()
     );
 
     const links = linkLists
       .map((linkList) => Object.values(linkList))
       .flat();
+
     const dependencies = links.map((link: any) => {
-      const sourcePort = (this.find(link) as Link)
-        .sourcePort;
+      const sourcePort = link.sourcePort;
       const sourceNode = (this.find(sourcePort.id) as Port)
         .node;
       return this.find(sourceNode.id);
     });
 
     const deepDependencies = dependencies.map((d) => {
-      return this.dependencies(this.find(d as any));
+      return this.dependencies(d);
     });
 
     const result = dependencies.concat(

--- a/src/server/Port.ts
+++ b/src/server/Port.ts
@@ -7,7 +7,6 @@ export class Port {
   name: string;
   features: Feature[];
   in: boolean;
-  links: any[] = [];
   id: string;
   node: Node;
 


### PR DESCRIPTION
The diagram `executionOrder()` silently did nothing, which lead to executing the nodes only in the order they were placed. So if not placed left to right there would be problems. This PR fixes it
