### PR TITLE
Downloader nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "",
   "devDependencies": {
+    "@types/browser-or-node": "^1.3.0",
     "@types/jest": "^27.0.1",
     "@typescript-eslint/eslint-plugin": "^4.29.1",
     "@typescript-eslint/parser": "^4.29.1",
@@ -63,6 +64,7 @@
   ],
   "dependencies": {
     "axios": "^0.21.1",
+    "browser-or-node": "^1.3.0",
     "laravel-mix": "^6.0.28"
   },
   "prettier": {

--- a/src/server/Diagram.ts
+++ b/src/server/Diagram.ts
@@ -4,7 +4,7 @@ import { DataStoryContext } from './DataStoryContext';
 import { Link } from './Link';
 import { Node } from './Node';
 import { Port } from './Port';
-import { isBrowser, isJsDom } from 'browser-or-node';
+import { isBrowser, isNode } from 'browser-or-node';
 import { DownloaderNode } from './DownloaderNode';
 
 export class Diagram {
@@ -33,7 +33,8 @@ export class Diagram {
       await node.run();
       if (
         node instanceof DownloaderNode &&
-        (isBrowser || isJsDom)
+        !isNode &&
+        isBrowser
       ) {
         await node.downloadData.download();
       }

--- a/src/server/Diagram.ts
+++ b/src/server/Diagram.ts
@@ -34,7 +34,7 @@ export class Diagram {
         node.category === 'Downloader' &&
         (isBrowser || isJsDom)
       ) {
-        await node.download();
+        await node.downloadData.download();
       }
     }
 

--- a/src/server/Diagram.ts
+++ b/src/server/Diagram.ts
@@ -4,6 +4,7 @@ import { DataStoryContext } from './DataStoryContext';
 import { Link } from './Link';
 import { Node } from './Node';
 import { Port } from './Port';
+import { isBrowser, isJsDom } from 'browser-or-node';
 
 export class Diagram {
   links: Link[] = [];
@@ -29,7 +30,10 @@ export class Diagram {
   async run() {
     for await (const node of this.executionOrder()) {
       await node.run();
-      if (node.category === 'Downloader') {
+      if (
+        node.category === 'Downloader' &&
+        (isBrowser || isJsDom)
+      ) {
         await node.download();
       }
     }

--- a/src/server/Diagram.ts
+++ b/src/server/Diagram.ts
@@ -5,6 +5,7 @@ import { Link } from './Link';
 import { Node } from './Node';
 import { Port } from './Port';
 import { isBrowser, isJsDom } from 'browser-or-node';
+import { DownloaderNode } from './DownloaderNode';
 
 export class Diagram {
   links: Link[] = [];
@@ -31,7 +32,7 @@ export class Diagram {
     for await (const node of this.executionOrder()) {
       await node.run();
       if (
-        node.category === 'Downloader' &&
+        node instanceof DownloaderNode &&
         (isBrowser || isJsDom)
       ) {
         await node.downloadData.download();

--- a/src/server/Diagram.ts
+++ b/src/server/Diagram.ts
@@ -29,6 +29,9 @@ export class Diagram {
   async run() {
     for await (const node of this.executionOrder()) {
       await node.run();
+      if (node.category === 'Downloader') {
+        await node.download();
+      }
     }
 
     return new Promise((callback) => {

--- a/src/server/DownloaderNode.ts
+++ b/src/server/DownloaderNode.ts
@@ -1,0 +1,6 @@
+import { DownloadData } from '../types';
+import { Node } from './Node';
+
+export abstract class DownloaderNode extends Node {
+  public downloadData: DownloadData<any>;
+}

--- a/src/server/Node.ts
+++ b/src/server/Node.ts
@@ -4,7 +4,11 @@ import { Feature } from '../Feature';
 import { UID } from '../utils';
 import { NodeParameter } from '../NodeParameter';
 import { Port } from './Port';
-import { DownloadData, SerializedPort } from '../types';
+import {
+  DownloadData,
+  DownloadDataI,
+  SerializedPort,
+} from '../types';
 
 type NodeOptions = {
   diagram?: Diagram;
@@ -38,35 +42,9 @@ export abstract class Node {
   public defaultInPorts: string[];
   public defaultOutPorts: string[];
   public features: any[];
-  public downloadData: DownloadData = {
-    data: [],
-    mimeType: 'application/json',
-    fileName: 'data-story-download',
-  };
+  public downloadData: DownloadData<any>;
 
   abstract run(): any;
-
-  public async download() {
-    const fileExtension = this.downloadData.mimeType
-      .split('/')
-      .pop();
-
-    const blob = new Blob([this.downloadData.data], {
-      type: this.downloadData.mimeType,
-    });
-
-    const href = await URL.createObjectURL(blob);
-    const link = document.createElement('a');
-
-    link.href = href;
-    link.download =
-      this.downloadData.fileName + `.${fileExtension}`;
-    // '.json';
-
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }
 
   constructor(options: NodeOptions = {}) {
     this.diagram = options.diagram;

--- a/src/server/Node.ts
+++ b/src/server/Node.ts
@@ -4,11 +4,7 @@ import { Feature } from '../Feature';
 import { UID } from '../utils';
 import { NodeParameter } from '../NodeParameter';
 import { Port } from './Port';
-import {
-  DownloadData,
-  DownloadDataI,
-  SerializedPort,
-} from '../types';
+import { SerializedPort } from '../types';
 
 type NodeOptions = {
   diagram?: Diagram;
@@ -42,7 +38,6 @@ export abstract class Node {
   public defaultInPorts: string[];
   public defaultOutPorts: string[];
   public features: any[];
-  public downloadData: DownloadData<any>;
 
   abstract run(): any;
 

--- a/src/server/Node.ts
+++ b/src/server/Node.ts
@@ -4,7 +4,7 @@ import { Feature } from '../Feature';
 import { UID } from '../utils';
 import { NodeParameter } from '../NodeParameter';
 import { Port } from './Port';
-import { SerializedPort } from '../types';
+import { DownloadData, SerializedPort } from '../types';
 
 type NodeOptions = {
   diagram?: Diagram;
@@ -38,8 +38,35 @@ export abstract class Node {
   public defaultInPorts: string[];
   public defaultOutPorts: string[];
   public features: any[];
+  public downloadData: DownloadData = {
+    data: [],
+    mimeType: 'application/json',
+    fileName: 'data-story-download',
+  };
 
   abstract run(): any;
+
+  public async download() {
+    const fileExtension = this.downloadData.mimeType
+      .split('/')
+      .pop();
+
+    const blob = new Blob([this.downloadData.data], {
+      type: this.downloadData.mimeType,
+    });
+
+    const href = await URL.createObjectURL(blob);
+    const link = document.createElement('a');
+
+    link.href = href;
+    link.download =
+      this.downloadData.fileName + `.${fileExtension}`;
+    // '.json';
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
 
   constructor(options: NodeOptions = {}) {
     this.diagram = options.diagram;

--- a/src/server/NodeFactory.ts
+++ b/src/server/NodeFactory.ts
@@ -9,7 +9,7 @@ import {
   CreateJSON,
   CreateSequence,
   // DownloadCSV,
-  // DownloadJSON,
+  DownloadJSON,
   // DownloadGeoJSON,
   Evaluate,
   FilterDuplicates,
@@ -70,6 +70,7 @@ export class NodeFactory {
     Sleep,
     Sort,
     ThrowError,
+    DownloadJSON,
   };
 
   static withContext(context) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,3 +7,4 @@ export { DataStoryContext } from './DataStoryContext';
 export { Link } from './Link';
 export { Node } from './Node';
 export { Port } from './Port';
+export * from './DownloaderNode';

--- a/src/server/nodes/DownloadJSON.ts
+++ b/src/server/nodes/DownloadJSON.ts
@@ -26,13 +26,11 @@ export class DownloadJSON extends DownloaderNode {
       toDownload.length === 1 && toDownload[0] === ''
     );
 
-    console.log(this.getParameterValue('node_name'));
-
-    const fileName = `data-story ${
-      this.parameters['name']
-    } ${new Date().toLocaleString('en-US', {
       hour12: false,
     })}`;
+    const fileName = `${this.getParameterValue(
+      'node_name',
+    )} ${new Date()
 
     this.downloadData = new DownloadData<any>({
       data: [],

--- a/src/server/nodes/DownloadJSON.ts
+++ b/src/server/nodes/DownloadJSON.ts
@@ -1,5 +1,6 @@
 import { Node } from '../Node';
 import { NodeParameter } from '../../NodeParameter';
+import { DownloadData } from '../../types';
 
 export class DownloadJSON extends Node {
   constructor(options = {}) {
@@ -25,10 +26,20 @@ export class DownloadJSON extends Node {
       toDownload.length === 1 && toDownload[0] === ''
     );
 
-    const fileName = `data-story-download ${new Date().toLocaleString(
-      'en-US',
-      { hour12: false },
-    )}`;
+    console.log(this.getParameterValue('node_name'));
+
+    const fileName = `data-story ${
+      this.parameters['name']
+    } ${new Date().toLocaleString('en-US', {
+      hour12: false,
+    })}`;
+
+    this.downloadData = new DownloadData<any>({
+      data: [],
+      mimeType: 'application/json',
+      fileName: fileName,
+      fileExtension: 'json',
+    });
 
     const latestAttribute = isToDownloadConfigured
       ? toDownload[toDownload.length - 1]
@@ -45,26 +56,17 @@ export class DownloadJSON extends Node {
           }, original);
 
           if (data !== undefined || data !== {}) {
-            this.downloadData = {
-              data: [
-                ...(this.downloadData.data ?? []),
-                {
-                  [latestAttribute]: data,
-                },
-              ],
-              mimeType: 'application/json',
-              fileName: fileName,
-            };
+            this.downloadData.data = [
+              ...this.downloadData.data,
+              {
+                [latestAttribute]: data,
+              },
+            ];
           }
         })
-      : (this.downloadData = {
-          data: this.input().map(
-            (feature) => feature.original,
-          ),
-
-          mimeType: 'application/json',
-          fileName: fileName,
-        });
+      : (this.downloadData.data = this.input().map(
+          (feature) => feature.original,
+        ));
 
     this.downloadData.data = JSON.stringify(
       this.downloadData.data,

--- a/src/server/nodes/DownloadJSON.ts
+++ b/src/server/nodes/DownloadJSON.ts
@@ -23,6 +23,10 @@ export class DownloadJSON extends DownloaderNode {
       'attribute to download',
     );
 
+    const toStringify = this.getParameterValue(
+      'pretty print json',
+    );
+
     const isToDownloadConfigured = !(toDownload === '');
 
     const fileName = `${this.getParameterValue(
@@ -63,9 +67,15 @@ export class DownloadJSON extends DownloaderNode {
           (feature) => feature.original,
         ));
 
-    this.downloadData.data = JSON.stringify(
-      this.downloadData.data,
-    );
+    toStringify == String('true')
+      ? (this.downloadData.data = JSON.stringify(
+          this.downloadData,
+          null,
+          4,
+        ))
+      : (this.downloadData.data = JSON.stringify(
+          this.downloadData.data,
+        ));
 
     // this.output(this.input());
   }
@@ -78,6 +88,9 @@ export class DownloadJSON extends DownloaderNode {
         .withDescription(
           'you may use dot notated paths, or ignore this field to download whole feature',
         ),
+      NodeParameter.select('pretty print json')
+        .withOptions(['true', 'false'])
+        .withValue('true'),
     ];
   }
 }

--- a/src/server/nodes/DownloadJSON.ts
+++ b/src/server/nodes/DownloadJSON.ts
@@ -1,5 +1,6 @@
 import { NodeParameter } from '../../NodeParameter';
 import { DownloadData } from '../../types';
+import { get } from '../../utils';
 import { DownloaderNode } from '../DownloaderNode';
 
 export class DownloadJSON extends DownloaderNode {
@@ -20,11 +21,9 @@ export class DownloadJSON extends DownloaderNode {
   async run() {
     const toDownload = this.getParameterValue(
       'attribute to download',
-    ).split('.');
-
-    const isToDownloadConfigured = !(
-      toDownload.length === 1 && toDownload[0] === ''
     );
+
+    const isToDownloadConfigured = !(toDownload === '');
 
     const fileName = `${this.getParameterValue(
       'node_name',
@@ -41,21 +40,17 @@ export class DownloadJSON extends DownloaderNode {
       fileExtension: 'json',
     });
 
-    const latestAttribute = isToDownloadConfigured
-      ? toDownload[toDownload.length - 1]
-      : toDownload[0];
+    const toDownloadAttrs = toDownload.split('.');
+    const latestAttribute =
+      toDownloadAttrs[toDownloadAttrs.length - 1];
 
     isToDownloadConfigured
       ? this.input().forEach((feature) => {
           const { original } = feature;
 
-          const data = toDownload.reduce((obj, path) => {
-            return obj && obj[path] !== undefined
-              ? obj[path]
-              : {};
-          }, original);
+          const data = get(original, toDownload);
 
-          if (data !== undefined || data !== {}) {
+          if (data !== null) {
             this.downloadData.data = [
               ...this.downloadData.data,
               {

--- a/src/server/nodes/DownloadJSON.ts
+++ b/src/server/nodes/DownloadJSON.ts
@@ -1,8 +1,8 @@
-import { Node } from '../Node';
 import { NodeParameter } from '../../NodeParameter';
 import { DownloadData } from '../../types';
+import { DownloaderNode } from '../DownloaderNode';
 
-export class DownloadJSON extends Node {
+export class DownloadJSON extends DownloaderNode {
   constructor(options = {}) {
     super({
       // Defaults

--- a/src/server/nodes/DownloadJSON.ts
+++ b/src/server/nodes/DownloadJSON.ts
@@ -1,0 +1,86 @@
+import { Node } from '../Node';
+import { NodeParameter } from '../../NodeParameter';
+
+export class DownloadJSON extends Node {
+  constructor(options = {}) {
+    super({
+      // Defaults
+      name: 'DownloadJSON',
+      summary: 'Downloads features in JSON view',
+      category: 'Downloader',
+      defaultInPorts: ['Input'],
+      defaultOutPorts: [],
+      // defaultOutPorts: ['Output'],
+      // Explicitly configured
+      ...options,
+    });
+  }
+
+  async run() {
+    const toDownload = this.getParameterValue(
+      'attribute to download',
+    ).split('.');
+
+    const isToDownloadConfigured = !(
+      toDownload.length === 1 && toDownload[0] === ''
+    );
+
+    const fileName = `data-story-download ${new Date().toLocaleString(
+      'en-US',
+      { hour12: false },
+    )}`;
+
+    const latestAttribute = isToDownloadConfigured
+      ? toDownload[toDownload.length - 1]
+      : toDownload[0];
+
+    isToDownloadConfigured
+      ? this.input().forEach((feature) => {
+          const { original } = feature;
+
+          const data = toDownload.reduce((obj, path) => {
+            return obj && obj[path] !== undefined
+              ? obj[path]
+              : {};
+          }, original);
+
+          if (data !== undefined || data !== {}) {
+            this.downloadData = {
+              data: [
+                ...(this.downloadData.data ?? []),
+                {
+                  [latestAttribute]: data,
+                },
+              ],
+              mimeType: 'application/json',
+              fileName: fileName,
+            };
+          }
+        })
+      : (this.downloadData = {
+          data: this.input().map(
+            (feature) => feature.original,
+          ),
+
+          mimeType: 'application/json',
+          fileName: fileName,
+        });
+
+    this.downloadData.data = JSON.stringify(
+      this.downloadData.data,
+    );
+
+    // this.output(this.input());
+  }
+
+  getDefaultParameters() {
+    return [
+      ...super.getDefaultParameters(),
+      NodeParameter.string('attribute to download')
+        .withValue('')
+        .withDescription(
+          'you may use dot notated paths, or ignore this field to download whole feature',
+        ),
+    ];
+  }
+}

--- a/src/server/nodes/DownloadJSON.ts
+++ b/src/server/nodes/DownloadJSON.ts
@@ -26,11 +26,13 @@ export class DownloadJSON extends DownloaderNode {
       toDownload.length === 1 && toDownload[0] === ''
     );
 
-      hour12: false,
-    })}`;
     const fileName = `${this.getParameterValue(
       'node_name',
     )} ${new Date()
+      .toLocaleString('en-US', {
+        hour12: false,
+      })
+      .replace(/:/gi, '_')}`;
 
     this.downloadData = new DownloadData<any>({
       data: [],

--- a/src/server/nodes/index.ts
+++ b/src/server/nodes/index.ts
@@ -25,3 +25,4 @@ export * from './Sleep';
 export * from './ThrowError';
 export * from './RemoveAttributes';
 export * from './RenameAttributes';
+export * from './DownloadJSON';

--- a/src/types/DownloadData.ts
+++ b/src/types/DownloadData.ts
@@ -12,9 +12,12 @@ export class DownloadData<T> {
   fileExtension: string;
 
   public async download() {
-    const blob = new Blob([this.data], {
-      type: this.mimeType,
-    });
+    const blob = new Blob(
+      [this.data as unknown as BlobPart],
+      {
+        type: this.mimeType,
+      },
+    );
 
     const href = await URL.createObjectURL(blob);
     const link = document.createElement('a');

--- a/src/types/DownloadData.ts
+++ b/src/types/DownloadData.ts
@@ -1,0 +1,5 @@
+export interface DownloadData {
+  data: any;
+  mimeType: string;
+  fileName: string;
+}

--- a/src/types/DownloadData.ts
+++ b/src/types/DownloadData.ts
@@ -1,5 +1,37 @@
-export interface DownloadData {
-  data: any;
+export interface DownloadDataI<T> {
+  data: T;
   mimeType: string;
   fileName: string;
+  fileExtension: string;
+}
+
+export class DownloadData<T> {
+  data: T;
+  mimeType: string;
+  fileName: string;
+  fileExtension: string;
+
+  public async download() {
+    const blob = new Blob([this.data], {
+      type: this.mimeType,
+    });
+
+    const href = await URL.createObjectURL(blob);
+    const link = document.createElement('a');
+
+    link.href = href;
+    link.download =
+      this.fileName + `.${this.fileExtension}`;
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+
+  constructor(options: DownloadDataI<T>) {
+    this.data = options.data;
+    this.mimeType = options.mimeType;
+    this.fileName = options.fileName;
+    this.fileExtension = options.fileExtension;
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export { SerializedDiagram } from './SerializedDiagram';
 export { SerializedLink } from './SerializedLink';
 export { SerializedNode } from './SerializedNode';
 export { SerializedPort } from './SerializedPort';
+export * from './DownloadData';

--- a/tests/Unit/server/nodes/DownloadJSON.test.ts
+++ b/tests/Unit/server/nodes/DownloadJSON.test.ts
@@ -30,6 +30,34 @@ describe('DownloadJSON node', () => {
       .finish();
   });
 
+  it('Pretty prints when enabled', async () => {
+    const randomData1 = generateRandomString();
+    const randomData2 = generateRandomString();
+
+    await when(DownloadJSON)
+      .hasInput([
+        {
+          value1: randomData1,
+          value2: randomData2,
+        },
+      ])
+      .and()
+      .parameters({
+        'attributes to download': [''],
+        'pretty print json': 'true',
+      })
+      .assertDownloads(
+        [
+          {
+            value1: randomData1,
+            value2: randomData2,
+          },
+        ],
+        true,
+      )
+      .finish();
+  });
+
   it('Supports dot-notated paths', async () => {
     const randomData1 = generateRandomString();
     const randomData2 = generateRandomString();

--- a/tests/Unit/server/nodes/DownloadJSON.test.ts
+++ b/tests/Unit/server/nodes/DownloadJSON.test.ts
@@ -1,0 +1,74 @@
+import { when } from '../NodeTester';
+import { DownloadJSON } from '../../../../src/server/nodes';
+import { generateRandomString } from '../../../helpers';
+
+describe('DownloadJSON node', () => {
+  global.URL.createObjectURL = jest.fn();
+
+  it('Generates right data to download', async () => {
+    const randomData1 = generateRandomString();
+    const randomData2 = generateRandomString();
+
+    await when(DownloadJSON)
+      .hasInput([
+        {
+          value1: randomData1,
+          value2: randomData2,
+        },
+      ])
+      .and()
+      .parameters({
+        'attributes to download': [''],
+        'pretty print json': 'false',
+      })
+      .assertDownloads([
+        {
+          value1: randomData1,
+          value2: randomData2,
+        },
+      ])
+      .finish();
+  });
+
+  it('Supports dot-notated paths', async () => {
+    const randomData1 = generateRandomString();
+    const randomData2 = generateRandomString();
+    const randomData3 = generateRandomString();
+
+    const feature = {
+      value1: {
+        deeper: {
+          nested: randomData1,
+        },
+      },
+      value2: randomData2,
+      value3: {
+        deeper: {
+          evenDeeper: {
+            value: randomData3,
+          },
+        },
+      },
+    };
+
+    await when(DownloadJSON)
+      .hasInput([feature])
+      .and()
+      .parameters({
+        'attributes to download': [
+          'value1.deeper.nested',
+          'value2',
+          'value3.deeper.evenDeeper.value',
+        ],
+        'pretty print json': 'false',
+      })
+      .assertDownloads([
+        {
+          nested: randomData1,
+          value2: randomData2,
+          value: randomData3,
+        },
+      ])
+      .finish();
+  });
+});

--- a/tests/Unit/server/nodes/Filter.test.ts
+++ b/tests/Unit/server/nodes/Filter.test.ts
@@ -18,7 +18,6 @@ describe('Filter node', () => {
       })
       .and()
       .dynamicPorts(['upcoming', 'sold'])
-      .and()
       .assertOutputs({
         Unfiltered: [{ status: 'for-sale' }],
         upcoming: [{ status: 'upcoming' }],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "es2020" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": [
-      "ES2020"
+      "ES2020",
+      "dom"
     ] /* Specify library files to be included in the compilation. */,
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,6 +1224,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/browser-or-node@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/browser-or-node/-/browser-or-node-1.3.0.tgz#896ec59bcb8109fc858d8e68d3c056c176a19622"
+  integrity sha512-MVetr65IR7RdJbUxVHsaPFaXAO8fi89zv1g8L/mHygh1Q7xnnK02XZLwfMh57FOpTO6gtnagoPMQ/UOFfctXRQ==
+
 "@types/clean-css@^4.2.4":
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/@types/clean-css/-/clean-css-4.2.5.tgz#69ce62cc13557c90ca40460133f672dc52ceaf89"
@@ -2096,6 +2101,11 @@ brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
+
+browser-or-node@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-or-node/-/browser-or-node-1.3.0.tgz#f2a4e8568f60263050a6714b2cc236bb976647a7"
+  integrity sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# Updates


## Downloader nodes

It&rsquo;s now possible to create nodes which will download resulting data in the browser.


# Implementation details


## DownloaderNode

Simple class that extends default Node type adding one extra property &#x2014; downloadData, which is supposed to be filled by Node on run execution.


## DownloadData

Class that holds:

-   data
-   mimeType of that data
-   fileName
-   fileExtension

This class have pretty generic download method that can be reused among most common cases, so all required work for every specific down-loader node is to specify right data, mimeType and fileName, everything about the downloading will be handled by DownloadData.

Class also supports generics so it&rsquo;s possible to specify type of the Data downloaded, for now ti just any

```js
this.downloadData = new DownloadData<any>({
    data: [],
    mimeType: 'application/json',
    fileName: fileName,
    fileExtension: 'json',
});
```


## Diagram run 

To check what nodes are supposed to run with Diagram run method, we are simply doing a couple of checks

```js
if (
    // Check of whether node is downloader
    node instanceof DownloaderNode &&
    // Check of whether code runs in browser
    // environment
    (isBrowser || isJsDom)
) {
    await node.downloadData.download();
}
```


## DownloadJSON node

Can be ran with dot-notated paths, so if we for example specify ***title*** as an attribute to download, we will get only those attributes from all features. Filename will be in such format
```js
[node_name] [date_downloaded].json
```
![2021-08-28_21-42-03](https://user-images.githubusercontent.com/49302467/131227787-adfe04cb-dbab-4a33-9278-0c004823d07c.png)



# Example of usage
![2021-08-28-20:53:43_compressed](https://user-images.githubusercontent.com/49302467/131227780-2e82c702-d0ee-4181-aa4d-dd70404756ad.gif)

