### PR TITLE
Remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "lint:quiet:fix": "npm run lint:fix -- --quiet",
     "test": "jest --config tests/jest.config.js",
     "prepare": "npm run build",
-    "postinstall": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
     "version": "npm run format && git add -A src",


### PR DESCRIPTION
# Prerequisites
The case when core is being installed from git is already handled by prepare script which also installs all required dependencies and devDependencies. 
