### PR TITLE
Add release workflow for publishing the core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,9 @@ jobs:
       - name: Install dependencies
         run: yarn --silent
 
-      - id: get_version
-        uses: battila7/get-version-action@v2
-
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          tag: ${{ steps.get_version.outputs.version-without-v }}
           check-version: false
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          access: 'public'
           check-version: false
-
 
       - if: steps.publish.outputs.type != 'none'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,3 @@ jobs:
           token: ${{ secrets.NPM_TOKEN }}
           access: 'public'
           check-version: false
-
-      - if: steps.publish.outputs.type != 'none'
-        run: |
-          echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  release_core_on_npm:
+    name: "Build and release core"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: yarn --silent
+
+      - id: get_version
+        uses: battila7/get-version-action@v2
+
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: ${{ steps.get_version.outputs.version-without-v }}
+
+
+      - if: steps.publish.outputs.type != 'none'
+        run: |
+          echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ steps.get_version.outputs.version-without-v }}
+          check-version: false
 
 
       - if: steps.publish.outputs.type != 'none'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story-org/core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -60,15 +60,15 @@
     "ts-loader": "^9.2.5",
     "typescript": "^4.4.2",
     "webpack": "^5.51.1",
-    "webpack-cli": "^4.8.0"
+    "webpack-cli": "^4.8.0",
+    "laravel-mix": "^6.0.28"
   },
   "files": [
     "lib/**/*"
   ],
   "dependencies": {
     "axios": "^0.21.1",
-    "browser-or-node": "^1.3.0",
-    "laravel-mix": "^6.0.28"
+    "browser-or-node": "^1.3.0"
   },
   "prettier": {
     "printWidth": 60,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story-org/core",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "lint:quiet:fix": "npm run lint:fix -- --quiet",
     "test": "jest --config tests/jest.config.js",
     "prepare": "npm run build",
-    "postinstall": "npm run build",
-    "prepublishOnly": "npm test && npm run lint",
+    "prepublishOnly": "npm test && npm run lint:quiet:fix && npm run build",
     "preversion": "npm run lint",
     "version": "npm run format && git add -A src",
     "postversion": "git push && git push --tags"


### PR DESCRIPTION
# Updates
- new release workflow which publishes core to the package registry whenever new tags pushed to the repo
- before publishing core is tested, so broken code won't be published
- all fixable errors are also fixed with eslint before publishing
- postinstall script removed as it no longer needed

This requires adding NPM_TOKEN secret in repo settings. Token creation process described [here](https://docs.npmjs.com/creating-and-viewing-access-tokens), for our purposes we need an automation one.