### PR TITLE
Add abillity to specify extra nodes on boot

### DIFF
--- a/src/server/DiagramFactory.ts
+++ b/src/server/DiagramFactory.ts
@@ -20,14 +20,17 @@ export class DiagramFactory {
     this.context = context;
   }
 
-  hydrate(data: SerializedDiagram): Diagram {
+  hydrate(
+    data: SerializedDiagram,
+    nodeFactory: NodeFactory,
+  ): Diagram {
     // Create empty diagram
     const diagram = new Diagram(this.context);
 
     // Add Nodes
     diagram.nodes = Object.values(data.nodes).map(
       (node: SerializedNode) => {
-        return new NodeFactory().hydrate(node, diagram);
+        return nodeFactory.hydrate(node, diagram);
       },
     );
 

--- a/src/server/NodeFactory.ts
+++ b/src/server/NodeFactory.ts
@@ -19,6 +19,16 @@ export class NodeFactory {
     return new this(context);
   }
 
+  withNodes(nodes) {
+    nodes.forEach((node) => {
+      this.prototypes = {
+        ...this.prototypes,
+        [new node().name]: node,
+      };
+    });
+    return this;
+  }
+
   constructor(context = {}) {
     this.context = context;
   }

--- a/src/server/Server.ts
+++ b/src/server/Server.ts
@@ -6,19 +6,21 @@ import { DataStoryContext } from './DataStoryContext';
 
 export class Server {
   context: DataStoryContext;
+  nodeFactory: NodeFactory;
 
   constructor(context = {}) {
     this.context = context;
+    this.nodeFactory = NodeFactory.withContext(context);
   }
 
-  public boot() {
+  public boot(extraNodes?) {
     return new Promise<BootPayload>((callback) => {
       return callback({
         data: {
           stories: [],
-          availableNodes: NodeFactory.withContext(
-            this.context,
-          ).nodeDescriptions(),
+          availableNodes: this.nodeFactory
+            .withNodes(extraNodes ?? [])
+            .nodeDescriptions(),
         },
       });
     });
@@ -28,7 +30,10 @@ export class Server {
     diagram: SerializedDiagram,
   ): Promise<{}> {
     return DiagramFactory.withContext(this.context)
-      .hydrate(diagram as SerializedDiagram)
+      .hydrate(
+        diagram as SerializedDiagram,
+        this.nodeFactory,
+      )
       .run();
   }
 


### PR DESCRIPTION
# Updates
## Server extra nodes specifying
Can be used like here
```js
Server.boot([CustomInspectNode, AnotherCustomNode]);
```
## NodeFactory 
Instead of creating NodeFactory instance every time in a couple of function we will instead hold it as Server member, so it's possible to keep extra nodes added
## withNodes method
add's extra nodes to default prototypes