### PR TITLE
Flatten diagram run results, fix BootPayload types to hold serializedModel field

### DIFF
--- a/src/server/Diagram.ts
+++ b/src/server/Diagram.ts
@@ -8,6 +8,10 @@ import { DownloaderNode } from './DownloaderNode';
 import { Output } from './nodes';
 import { Feature } from '../Feature';
 
+export interface DiagramRunResult {
+  diagram: Diagram;
+}
+
 export class Diagram {
   links: Link[] = [];
   nodes: Node[] = [];
@@ -36,7 +40,7 @@ export class Diagram {
     });
   }
 
-  async run(inputMap = {}) {
+  async run(inputMap = {}): Promise<DiagramRunResult> {
     this.populateInputs(inputMap);
 
     for await (const node of this.executionOrder()) {
@@ -48,9 +52,7 @@ export class Diagram {
 
     return new Promise((callback) => {
       return callback({
-        data: {
-          diagram: this,
-        },
+        diagram: this,
       });
     });
   }

--- a/src/types/BootPayload.ts
+++ b/src/types/BootPayload.ts
@@ -1,6 +1,9 @@
+import { SerializedDiagram } from './SerializedDiagram';
+
 export interface BootPayload {
   data: {
     stories?: string[];
     availableNodes: object[];
+    serializedModel?: SerializedDiagram;
   };
 }

--- a/tests/Unit/server/Diagram.test.ts
+++ b/tests/Unit/server/Diagram.test.ts
@@ -70,12 +70,12 @@ describe('Outputs', () => {
 
     let afterRunning = (
       (await getDiagram().run()) as any
-    ).data.diagram.getOutput();
+    ).diagram.getOutput();
     expect(afterRunning).toStrictEqual(defaultOutput);
 
     let explicit = (
       (await getDiagram().run()) as any
-    ).data.diagram.getOutput('Output');
+    ).diagram.getOutput('Output');
     expect(explicit).toStrictEqual(defaultOutput);
   });
 
@@ -85,14 +85,14 @@ describe('Outputs', () => {
 
     let afterRunning = (
       (await getDiagram().run()) as any
-    ).data.diagram.getOutputFeatures();
+    ).diagram.getOutputFeatures();
     expect(afterRunning).toStrictEqual(
       defaultOutputFeatures,
     );
 
     let explicit = (
       (await getDiagram().run()) as any
-    ).data.diagram.getOutputFeatures('Output');
+    ).diagram.getOutputFeatures('Output');
     expect(explicit).toStrictEqual(defaultOutputFeatures);
   });
 });
@@ -110,8 +110,8 @@ describe('Outputs', () => {
     let runResult: any = await getDiagram().run({
       Input: [1, 2, 3].map((n) => new Feature(n)),
     });
-    expect(
-      runResult.data.diagram.getOutput(),
-    ).toStrictEqual([3, 6, 9]);
+    expect(runResult.diagram.getOutput()).toStrictEqual([
+      3, 6, 9,
+    ]);
   });
 });

--- a/tests/Unit/server/NodeTester.ts
+++ b/tests/Unit/server/NodeTester.ts
@@ -270,7 +270,7 @@ export class NodeTester {
     await this.diagram
       .run()
       .then((result: any) => {
-        this.runResult = result.data.diagram;
+        this.runResult = result.diagram;
         this.ranSuccessfully = true;
       })
       .catch((f) => {


### PR DESCRIPTION
# Updates
- _data { diagram }_ is flattened to just _diagram_
- fixed BootPayload interface so it holds serializedModel which is being used on gui boot

related to data-story-org/gui#186