### PR TITLE
Add node ScrapeHTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,20 +55,21 @@
     "eslint": "^7.32.0",
     "eslint-plugin-jest": "^24.4.0",
     "jest": "^26.6.0",
+    "laravel-mix": "^6.0.28",
     "prettier": "^2.3.2",
     "ts-jest": "^26.4.1",
     "ts-loader": "^9.2.5",
     "typescript": "^4.4.2",
     "webpack": "^5.51.1",
-    "webpack-cli": "^4.8.0",
-    "laravel-mix": "^6.0.28"
+    "webpack-cli": "^4.8.0"
   },
   "files": [
     "lib/**/*"
   ],
   "dependencies": {
     "axios": "^0.21.1",
-    "browser-or-node": "^1.3.0"
+    "browser-or-node": "^1.3.0",
+    "cheerio": "^1.0.0-rc.10"
   },
   "prettier": {
     "printWidth": 60,

--- a/src/server/nodes/ScrapeHTML.ts
+++ b/src/server/nodes/ScrapeHTML.ts
@@ -19,14 +19,15 @@ export class ScrapeHTML extends Node {
 	}
 
 	async run() {
-		const proxy = 'https://nameless-dawn-49509.herokuapp.com'
-		const url = 'https://www.hemnet.se/bostader'
-		const selector = '.normal-results__hit'
+		const proxy = this.getParameterValue('proxy')
+		const url = this.getParameterValue('url')
+		const fullUrl = (proxy ? proxy + '/': '') + url
+		const selector = this.getParameterValue('Root selector')
 		const config = {
 			'X-Requested-With': 'XMLHttpRequest'
 		} as AxiosRequestConfig
 	
-		await axios.get(`${proxy}/${url}`, config)
+		await axios.get(fullUrl, config)
 			.then((response) => {
 				const $ = cheerio.load(response.data);
 				
@@ -69,7 +70,7 @@ export class ScrapeHTML extends Node {
 		return feature
 	}
 
-	extractAttributeValue(element, selector, method): string {
+	extractAttributeValue(element, selector, method = 'single'): string {
 		const $ = cheerio.load(element);
 
 		if(method != 'single') return;
@@ -80,6 +81,8 @@ export class ScrapeHTML extends Node {
   getDefaultParameters() {
     return [
       ...super.getDefaultParameters(),
+			NodeParameter.string('url').withValue('https://www.hemnet.se/bostader'),
+			NodeParameter.string('proxy').withValue('https://nameless-dawn-49509.herokuapp.com'),
 			NodeParameter.string('Root selector').withValue('.normal-results__hit'),
       NodeParameter.row('Attribute extractions', [
         NodeParameter.string('attribute').withValue(

--- a/src/server/nodes/ScrapeHTML.ts
+++ b/src/server/nodes/ScrapeHTML.ts
@@ -2,7 +2,7 @@ import { Node } from "../Node";
 import { NodeParameter } from "../../NodeParameter";
 import axios, { AxiosRequestConfig } from "axios";
 import { Feature } from "../../Feature";
-const cheerio = require('cheerio');
+import cheerio from 'cheerio'
 
 export class ScrapeHTML extends Node {
 	constructor(options = {}) {
@@ -31,7 +31,7 @@ export class ScrapeHTML extends Node {
 				const $ = cheerio.load(response.data);
 				
 				const elements = $(selector);
-				let features = this.toFeatures(elements)
+				const features = this.toFeatures(elements)
 				this.output(features)
 			})
 			.catch((reason) => {
@@ -40,7 +40,7 @@ export class ScrapeHTML extends Node {
 			});			
 	}
 	
-	toFeatures(elements) {
+	toFeatures(elements): Feature[] {
 		const features = []
 		
 		for (let i = 0; i < elements.length; i++) {
@@ -51,7 +51,7 @@ export class ScrapeHTML extends Node {
 		return features
 	}
 
-	extractFeature(element) {
+	extractFeature(element): Feature {
     const extractions = this.getParameterValue('Attribute extractions');		
 		const feature = new Feature({})
 
@@ -69,7 +69,7 @@ export class ScrapeHTML extends Node {
 		return feature
 	}
 
-	extractAttributeValue(element, selector, method) {
+	extractAttributeValue(element, selector, method): string {
 		const $ = cheerio.load(element);
 
 		if(method != 'single') return;

--- a/src/server/nodes/ScrapeHTML.ts
+++ b/src/server/nodes/ScrapeHTML.ts
@@ -3,7 +3,6 @@ import { NodeParameter } from "../../NodeParameter";
 import axios, { AxiosRequestConfig } from "axios";
 import { Feature } from "../../Feature";
 const cheerio = require('cheerio');
-import { nonCircularJsonStringify } from '@data-story-org/core/utils';
 
 export class ScrapeHTML extends Node {
 	constructor(options = {}) {

--- a/src/server/nodes/ScrapeHTML.ts
+++ b/src/server/nodes/ScrapeHTML.ts
@@ -1,0 +1,99 @@
+import { Node } from "../Node";
+import { NodeParameter } from "../../NodeParameter";
+import axios, { AxiosRequestConfig } from "axios";
+import { Feature } from "../../Feature";
+const cheerio = require('cheerio');
+import { nonCircularJsonStringify } from '@data-story-org/core/utils';
+
+export class ScrapeHTML extends Node {
+	constructor(options = {}) {
+		super({
+			// Defaults
+			name: 'ScrapeHTML',
+			summary: 'Scrapes static HTML content lists. Might need a proxy.',
+			category: 'Workflow',
+			defaultInPorts: [],
+			defaultOutPorts: ['Output', 'Failed'],			
+			// Explicitly configured
+			...options,
+		})
+	}
+
+	async run() {
+		const proxy = 'https://nameless-dawn-49509.herokuapp.com'
+		const url = 'https://www.hemnet.se/bostader'
+		const selector = '.normal-results__hit'
+		const config = {
+			'X-Requested-With': 'XMLHttpRequest'
+		} as AxiosRequestConfig
+	
+		await axios.get(`${proxy}/${url}`, config)
+			.then((response) => {
+				const $ = cheerio.load(response.data);
+				
+				const elements = $(selector);
+				let features = this.toFeatures(elements)
+				this.output(features)
+			})
+			.catch((reason) => {
+				console.log(reason)
+				throw(reason)
+			});			
+	}
+	
+	toFeatures(elements) {
+		const features = []
+		
+		for (let i = 0; i < elements.length; i++) {
+			const root = elements[i]
+			features.push(this.extractFeature(root))
+		}
+
+		return features
+	}
+
+	extractFeature(element) {
+    const extractions = this.getParameterValue('Attribute extractions');		
+		const feature = new Feature({})
+
+		extractions.forEach((extraction) => {
+			const attributeName = extraction['attribute']['value']
+			const selector = extraction['selector']['value']
+			const method = extraction['method']['value']
+			
+			feature.set(
+				attributeName,
+				this.extractAttributeValue(element, selector, method)
+			)
+		});
+
+		return feature
+	}
+
+	extractAttributeValue(element, selector, method) {
+		const $ = cheerio.load(element);
+
+		if(method != 'single') return;
+
+		return $(selector)[0].firstChild.data
+	}
+
+  getDefaultParameters() {
+    return [
+      ...super.getDefaultParameters(),
+			NodeParameter.string('Root selector').withValue('.normal-results__hit'),
+      NodeParameter.row('Attribute extractions', [
+        NodeParameter.string('attribute').withValue(
+          'address',
+        ),
+        NodeParameter.string('selector').withValue(
+          '.listing-card__street-address',
+        ),
+				// Refactor to select
+        NodeParameter.string('method')
+					.withPlaceholder('single || multiple') // Ensure this works
+					.withValue('single') // Only single implemented at the moment
+      ]).repeatable(),
+    ];
+  }	
+}

--- a/src/server/nodes/index.ts
+++ b/src/server/nodes/index.ts
@@ -1,3 +1,4 @@
+
 export * from './Aggregate';
 export * from './Clone_';
 export * from './Comment';
@@ -26,6 +27,7 @@ export * from './RemoveAttributes';
 export * from './RenameAttributes';
 export * from './ResolveContextFeatures';
 export * from './Sample';
+export * from './ScrapeHTML';
 export * from './Sleep';
 export * from './Sort';
 export * from './ThrowError';

--- a/tests/Unit/server/nodes/ScrapeHTML.test.skip.ts
+++ b/tests/Unit/server/nodes/ScrapeHTML.test.skip.ts
@@ -1,0 +1,11 @@
+import { ScrapeHTML } from '../../../../src/server/nodes/ScrapeHTML'
+import { when } from "../NodeTester";
+
+describe('ScrapeHTML node', () => {
+	it('DESCRIPTION', async () => {
+		
+		await when(ScrapeHTML).hasDefaultParameters()
+			.assertCanRun()
+			.finish()
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2332,6 +2332,30 @@ charenc@0.0.2:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
+cheerio-select@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.5.0.tgz#faf3daeb31b17c5e1a9dabcee288aaf8aafa5823"
+  integrity sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==
+  dependencies:
+    css-select "^4.1.3"
+    css-what "^5.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+    domutils "^2.7.0"
+
+cheerio@^1.0.0-rc.10:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
+  integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
+  dependencies:
+    cheerio-select "^1.5.0"
+    dom-serializer "^1.3.2"
+    domhandler "^4.2.0"
+    htmlparser2 "^6.1.0"
+    parse5 "^6.0.1"
+    parse5-htmlparser2-tree-adapter "^6.0.1"
+    tslib "^2.2.0"
+
 chokidar@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
@@ -2770,7 +2794,7 @@ css-tree@^1.1.2:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
-css-what@^5.0.0:
+css-what@^5.0.0, css-what@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
   integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
@@ -3061,7 +3085,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-serializer@^1.0.1:
+dom-serializer@^1.0.1, dom-serializer@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
   integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
@@ -3094,6 +3118,13 @@ domhandler@^3.0.0:
   dependencies:
     domelementtype "^2.0.1"
 
+domhandler@^4.0.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.2.tgz#e825d721d19a86b8c201a35264e226c678ee755f"
+  integrity sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==
+  dependencies:
+    domelementtype "^2.2.0"
+
 domhandler@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
@@ -3105,6 +3136,15 @@ domutils@^2.0.0, domutils@^2.6.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.7.0.tgz#8ebaf0c41ebafcf55b0b72ec31c56323712c5442"
   integrity sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+
+domutils@^2.5.2, domutils@^2.7.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
   dependencies:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
@@ -4052,6 +4092,16 @@ htmlparser2@^4.1.0:
     domelementtype "^2.0.1"
     domhandler "^3.0.0"
     domutils "^2.0.0"
+    entities "^2.0.0"
+
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
     entities "^2.0.0"
 
 http-deceiver@^1.2.7:
@@ -5969,7 +6019,14 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-parse5@6.0.1:
+parse5-htmlparser2-tree-adapter@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@6.0.1, parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
@@ -7534,6 +7591,11 @@ tslib@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
### Extracts data from websites:
![image](https://user-images.githubusercontent.com/3457668/135710582-e790ee74-f8cc-4d82-9cf5-d28a1a60a25d.png)

### Configure:
![image](https://user-images.githubusercontent.com/3457668/135730013-18dc300e-27f9-4ba2-ae10-723bbe47e98b.png)

### Result:
![image](https://user-images.githubusercontent.com/3457668/135710717-c29d5616-cb3b-4dc3-92fd-ed97d94128ab.png)

There were 50 cards (root selectors) on the website hence 50 features in output

![image](https://user-images.githubusercontent.com/3457668/135710665-9665d727-324b-4f03-b42c-dc42362001f5.png)

### Notes/Todos
* only supports basic html  and no intention of supporting JS-rendered content in this node
* make a system for us to mock axios in tests for this and other nodes
* implement 'multiple' to extract lists of things. Example something like: root[element].keywords/tags
* could benefit from some improvements of repeatables as documented in trello
* How to return type on run() Promise<?> - move RunResult interface to core!
* Find and set types for element/html-nodes