### PR TITLE
Backward compatibility exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,13 @@
   "exports": {
     ".": "./lib/src/index.js",
     "./utils": "./lib/src/utils/index.js",
-    "./nodes": "./lib/src/server/nodes/index.js"
+    "./nodes": "./lib/src/server/nodes/index.js",
+    "./lib/": "./lib/"
   },
   "typesVersions": {
     "*": {
-      "utils": [
-        "lib/src/utils/index.d.ts"
-      ],
-      "nodes": [
-        "lib/src/server/nodes/index.d.ts"
-      ]
+      "utils": ["lib/src/utils/index.d.ts"],
+      "nodes": ["lib/src/server/nodes/index.d.ts"]
     }
   },
   "scripts": {
@@ -38,9 +35,7 @@
     "type": "git",
     "url": ""
   },
-  "keywords": [
-    "typescript"
-  ],
+  "keywords": ["typescript"],
   "author": "",
   "license": "MIT",
   "bugs": {
@@ -63,9 +58,7 @@
     "webpack": "^5.51.1",
     "webpack-cli": "^4.8.0"
   },
-  "files": [
-    "lib/**/*"
-  ],
+  "files": ["lib/**/*"],
   "dependencies": {
     "axios": "^0.21.1",
     "browser-or-node": "^1.3.0",


### PR DESCRIPTION
# Prerequisites

As for now, many popular libraries still lacks of support for subpaths exports defined in package.json (as for example react-scripts which uses old webpack version, without package exports support). So in order to improve backward compatibility, core now allows direct imports from directories as well as subpaths exports.

<https://github.com/facebook/create-react-app/issues/10892> 
<https://github.com/facebook/create-react-app/issues/11528> 
<https://github.com/microsoft/TypeScript/issues/33079>