### PR TITLE
Multiple default values for repeatables

### DIFF
--- a/src/NodeParameter.ts
+++ b/src/NodeParameter.ts
@@ -1,3 +1,6 @@
+import { FixedSizeArray } from './types';
+import { cloneClass, zip } from './utils';
+
 type Repeatables = {
   [k: number]: any;
 };
@@ -25,6 +28,10 @@ type ComplexFieldType = 'Row' | 'Port';
 
 type FieldType = SimpleFieldType | ComplexFieldType;
 
+type RowValue = {
+  [parameterName: string]: NodeParameter;
+};
+
 export class NodeParameter {
   name: string;
   description = '';
@@ -34,6 +41,7 @@ export class NodeParameter {
   defaultValue: any = '';
   options?: string[];
   isRepeatable = false;
+  extraRowsDefaultValues: any[] = [];
   wrappedPortType: SimpleFieldType = 'String_';
 
   constructor(name: string, value: any = '') {
@@ -78,11 +86,37 @@ export class NodeParameter {
       .withWrappedPortType(wrappedFieldType);
   }
 
-  static row(name: string, params: NodeParameter[]) {
-    const value = Object.fromEntries(
-      params.map((p) => [p.name, p]),
+  static row<ColumnsLength extends number>(
+    name: string,
+    rowParams: FixedSizeArray<ColumnsLength, NodeParameter>,
+    extraDefaultRows: Array<
+      FixedSizeArray<ColumnsLength, any>
+    > = [],
+  ) {
+    const value: RowValue = Object.fromEntries(
+      rowParams.map((p) => [p.name, p]),
     );
-    return this.make(name, value).withFieldType('Row');
+
+    const extraRowsValues = extraDefaultRows.map(
+      (extraRowValues) =>
+        Object.fromEntries(
+          zip(rowParams, extraRowValues).map(
+            ([parameter, value]) => [
+              parameter.name,
+              cloneClass(parameter).withValue(value),
+            ],
+          ),
+        ),
+    );
+
+    return this.make(name, value)
+      .withFieldType('Row')
+      .withExtraRowsValues(extraRowsValues);
+  }
+
+  withExtraRowsValues(extraRowsValues: RowValue[]) {
+    this.extraRowsDefaultValues = extraRowsValues;
+    return this;
   }
 
   withFieldType(type: FieldType) {
@@ -115,9 +149,12 @@ export class NodeParameter {
     return this;
   }
 
-  repeatable() {
+  repeatable(extraDefaultValues: any[] = []) {
     this.defaultValue = this.value;
-    this.value = [this.value];
+    this.value =
+      this.fieldType === 'Row'
+        ? [this.value, ...this.extraRowsDefaultValues]
+        : [this.value, ...extraDefaultValues];
 
     this.isRepeatable = true;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,11 @@ export {
 } from './server';
 
 export {
+  NodeParameter,
+  repeatableConverter,
+} from './server/NodeParameter';
+
+export {
   SerializedDiagram,
   SerializedLink,
   SerializedNode,
@@ -18,7 +23,4 @@ export {
 } from './types';
 
 export { Feature } from './Feature';
-export { NodeParameter } from './NodeParameter';
-export { repeatableConverter } from './NodeParameter';
-
 export { demos } from './server/demos';

--- a/src/server/Node.ts
+++ b/src/server/Node.ts
@@ -2,7 +2,7 @@ import { Diagram } from './Diagram';
 import cloneDeep from 'lodash/cloneDeep';
 import { Feature } from '../Feature';
 import { UID } from '../utils';
-import { NodeParameter } from '../NodeParameter';
+import { NodeParameter } from './NodeParameter';
 import { Port } from './Port';
 import { SerializedPort } from '../types';
 

--- a/src/server/NodeParameter/NodeParameter.ts
+++ b/src/server/NodeParameter/NodeParameter.ts
@@ -117,7 +117,9 @@ export class NodeParameter {
       rowParams.map((p) => [p.name, p]),
     );
 
-    return this.make(name, value).withFieldType('Row');
+    return this.make(name, value)
+      .withFieldType('Row')
+      .repeatable();
   }
 
   withFieldType(type: FieldType) {
@@ -170,10 +172,12 @@ export class NodeParameter {
   }
 
   repeatable() {
-    this.defaultValue = this.value;
-    this.value = [this.value];
+    if (!this.isRepeatable) {
+      this.defaultValue = this.value;
+      this.value = [this.value];
 
-    this.isRepeatable = true;
+      this.isRepeatable = true;
+    }
 
     return this;
   }

--- a/src/server/NodeParameter/index.ts
+++ b/src/server/NodeParameter/index.ts
@@ -1,0 +1,1 @@
+export * from './NodeParameter';

--- a/src/server/nodes/Aggregate.ts
+++ b/src/server/nodes/Aggregate.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { groupBy } from '../../utils/Arr';
 import { Feature } from '../../Feature';
 

--- a/src/server/nodes/Clone_.ts
+++ b/src/server/nodes/Clone_.ts
@@ -1,4 +1,4 @@
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Node } from '../Node';
 
 export class Clone_ extends Node {

--- a/src/server/nodes/Comment.ts
+++ b/src/server/nodes/Comment.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class Comment extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/Create.ts
+++ b/src/server/nodes/Create.ts
@@ -1,6 +1,6 @@
 import { Node } from '../Node';
 import { Feature } from '../../Feature';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class Create extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/CreateAttribute.ts
+++ b/src/server/nodes/CreateAttribute.ts
@@ -1,6 +1,6 @@
 import { Node } from '../Node';
 import { Feature } from '../../Feature';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class CreateAttribute extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/CreateCSV.ts
+++ b/src/server/nodes/CreateCSV.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Feature } from '../../Feature';
 
 export class CreateCSV extends Node {

--- a/src/server/nodes/CreateGrid.ts
+++ b/src/server/nodes/CreateGrid.ts
@@ -1,6 +1,6 @@
 import { Feature } from '../../Feature';
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class CreateGrid extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/CreateJSON.ts
+++ b/src/server/nodes/CreateJSON.ts
@@ -1,6 +1,6 @@
 import { Feature } from '../../Feature';
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class CreateJSON extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/CreateSequence.ts
+++ b/src/server/nodes/CreateSequence.ts
@@ -1,6 +1,6 @@
 import { Feature } from '../../Feature';
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class CreateSequence extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/DownloadJSON.ts
+++ b/src/server/nodes/DownloadJSON.ts
@@ -1,4 +1,4 @@
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { DownloadData } from '../../types';
 import { get } from '../../utils';
 import { DownloaderNode } from '../DownloaderNode';

--- a/src/server/nodes/Evaluate.ts
+++ b/src/server/nodes/Evaluate.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Feature } from '../../Feature';
 
 const placeholder = `// PER FEATURE mode gives you access to variables: previous, current and next, ie

--- a/src/server/nodes/Filter.ts
+++ b/src/server/nodes/Filter.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class Filter extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/FilterDuplicates.ts
+++ b/src/server/nodes/FilterDuplicates.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Feature } from '../../Feature';
 
 export class FilterDuplicates extends Node {

--- a/src/server/nodes/HTTPRequest.ts
+++ b/src/server/nodes/HTTPRequest.ts
@@ -1,7 +1,7 @@
 import { Node } from '../Node';
 import axios from 'axios';
 import { Feature } from '../../Feature';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class HTTPRequest extends Node {
   client = axios;

--- a/src/server/nodes/Map.ts
+++ b/src/server/nodes/Map.ts
@@ -1,6 +1,6 @@
 import { Feature } from '../../Feature';
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class Map extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/Multiply.ts
+++ b/src/server/nodes/Multiply.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Feature } from '../../Feature';
 
 export class Multiply extends Node {

--- a/src/server/nodes/OutputProvider.ts
+++ b/src/server/nodes/OutputProvider.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Feature } from '../../Feature';
 
 export class OutputProvider extends Node {

--- a/src/server/nodes/RegExpFilter.ts
+++ b/src/server/nodes/RegExpFilter.ts
@@ -1,6 +1,6 @@
 import { Node } from '../Node';
 import { trim } from '../../utils/Str';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class RegExpFilter extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/RemoveAttributes.ts
+++ b/src/server/nodes/RemoveAttributes.ts
@@ -1,4 +1,4 @@
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Feature } from '../../Feature';
 import { Node } from '../Node';
 
@@ -45,7 +45,7 @@ export class RemoveAttributes extends Node {
       ...super.getDefaultParameters(),
       NodeParameter.string('Attributes to remove')
         .withPlaceholder('Attribute name')
-        .repeatable(),
+        .repeatable()
     ];
   }
 }

--- a/src/server/nodes/RenameAttributes.ts
+++ b/src/server/nodes/RenameAttributes.ts
@@ -1,4 +1,4 @@
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Feature } from '../../Feature';
 import { Node } from '../Node';
 import { renameKey } from '../../utils';

--- a/src/server/nodes/ResolveContextFeatures.ts
+++ b/src/server/nodes/ResolveContextFeatures.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Feature } from '../../Feature';
 
 export class ResolveContextFeatures extends Node {

--- a/src/server/nodes/RunDiagram.ts
+++ b/src/server/nodes/RunDiagram.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { DiagramRunResult } from '../Diagram';
 import { Feature } from '../../Feature';
 import { DiagramFactory } from '../DiagramFactory';

--- a/src/server/nodes/Sample.ts
+++ b/src/server/nodes/Sample.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class Sample extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/ScrapeHTML.ts
+++ b/src/server/nodes/ScrapeHTML.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import axios, { AxiosRequestConfig } from 'axios';
 import { Feature } from '../../Feature';
 import cheerio from 'cheerio';

--- a/src/server/nodes/Sleep.ts
+++ b/src/server/nodes/Sleep.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 
 export class Sleep extends Node {
   constructor(options = {}) {

--- a/src/server/nodes/Sort.ts
+++ b/src/server/nodes/Sort.ts
@@ -1,5 +1,5 @@
 import { Node } from '../Node';
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Feature } from '../../Feature';
 
 export class Sort extends Node {

--- a/src/server/nodes/ThrowError.ts
+++ b/src/server/nodes/ThrowError.ts
@@ -1,4 +1,4 @@
-import { NodeParameter } from '../../NodeParameter';
+import { NodeParameter } from '../NodeParameter';
 import { Node } from '../Node';
 
 export class ThrowError extends Node {

--- a/src/types/FixedSizeArray.ts
+++ b/src/types/FixedSizeArray.ts
@@ -1,0 +1,9 @@
+export type FixedSizeArray<
+  N extends number,
+  T,
+> = N extends 0
+  ? never[]
+  : {
+      0: T;
+      length: N;
+    } & Array<T>;

--- a/src/types/SerializedNode.ts
+++ b/src/types/SerializedNode.ts
@@ -1,4 +1,4 @@
-import { NodeParameter } from '../NodeParameter';
+import { NodeParameter } from '../server/NodeParameter';
 import { SerializedPort } from './SerializedPort';
 
 export type SerializedNode = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,4 @@ export { SerializedNode } from './SerializedNode';
 export { SerializedPort } from './SerializedPort';
 export * from './DownloadData';
 export * from './BootPayload';
+export * from './FixedSizeArray';

--- a/src/utils/Arr.ts
+++ b/src/utils/Arr.ts
@@ -13,7 +13,16 @@ export const groupBy = (items, key) => {
   );
 };
 
-export const zip = <A, B>(
-  a: Array<A> | ReadonlyArray<A>,
-  b: Array<B> | ReadonlyArray<B>,
-) => a.map((ele: A, i: number) => [ele, b[i]]);
+export const zip = (...arrays: Array<Array<any>>) => {
+  const minLen = Math.min(
+    ...arrays.map((arr) => arr.length),
+  );
+
+  const [firstArr, ...restArrs] = arrays;
+  return firstArr
+    .slice(0, minLen)
+    .map((val, i) => [
+      val,
+      ...restArrs.map((arr) => arr[i]),
+    ]);
+};

--- a/src/utils/Arr.ts
+++ b/src/utils/Arr.ts
@@ -12,3 +12,8 @@ export const groupBy = (items, key) => {
     {},
   );
 };
+
+export const zip = <A, B>(
+  a: Array<A> | ReadonlyArray<A>,
+  b: Array<B> | ReadonlyArray<B>,
+) => a.map((ele: A, i: number) => [ele, b[i]]);

--- a/src/utils/Obj.ts
+++ b/src/utils/Obj.ts
@@ -19,7 +19,13 @@ export const pickBy = (object, picker) => {
   return result;
 };
 
-const clone = (obj) => Object.assign({}, obj);
+export const clone = <T>(obj: T) => Object.assign({}, obj);
+
+export const cloneClass = <T>(obj: T) =>
+  Object.assign(
+    Object.create(Object.getPrototypeOf(obj)),
+    obj,
+  );
 
 export const renameKey = (object, key, newKey) => {
   const clonedObj = clone(object);


### PR DESCRIPTION
# Updates


## Multiple default values


### Rows

Now supports specifying extra rows with default values for parameters. Type-safety included, so length of row and length of extra rows with their default values forced to be the same.

Here&rsquo;s example how extra default values for rows can be specified

```js

NodeParameter.row('Atrribute & value to create', [
    NodeParameter.string('Attribute').withPlaceholder('attribute')
    NodeParameter.string('Value').withPlaceholder('value')
], [
    // List of extra rows with default values
    ['Default attribute', 'Default value'],
    ['Default attribute 2', 'Default value 2'],
]).repeatable()
```

![Screenshot 2021-10-29 at 11-43-00 DataStory](https://user-images.githubusercontent.com/49302467/139415203-bfed6950-13d0-42dc-8263-8f976dea299b.png)


### Primitive repeatables

Supports extra default values, which can be specified when calling repeatable method.

```js
NodeParameter.string('Attributes to remove')
    .withPlaceholder('Attribute name')
    .repeatable(['some', 'attr', 'yet another one']),
```

![Screenshot 2021-10-29 at 12-01-53 DataStory](https://user-images.githubusercontent.com/49302467/139415225-f14ce4d7-af86-4df4-ae2b-0dd189b7511f.png)
