### PR TITLE
Improve attribute templating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ dist
 
 # notes
 notes/
+
+# editors
+.vscode

--- a/src/Feature.ts
+++ b/src/Feature.ts
@@ -19,6 +19,43 @@ export class Feature {
     return this;
   }
 
+  public parse(template) {
+    /* eslint-disable no-useless-escape */
+    const matches = template.match(
+      /\{\{[\.a-zA-Z\s_]*\}\}/g,
+    );
+
+		if(!matches) return template;
+
+		let parsed = template;
+
+		for (const match of matches) {
+			const originalMatch = match;
+
+			const parts = match
+				.replace('{{', '')
+				.replace('}}', '')
+				.trim()
+				.split('.');
+
+			parts.shift(); // Remove 'feature'
+
+			const interpreted = parts.reduce(
+				(carry, property) => {
+					return carry[property];
+				},
+				this.original,
+			);
+
+			parsed = parsed.replace(
+				originalMatch,
+				interpreted,
+			);
+		}
+
+		return parsed;
+  }
+
   public type() {
     return typeof this.original;
   }

--- a/src/Feature.ts
+++ b/src/Feature.ts
@@ -19,7 +19,7 @@ export class Feature {
     return this;
   }
 
-  public parse(template) {
+  public parse(template: string): string {
     /* eslint-disable no-useless-escape */
     const matches = template.match(
       /\{\{[\.a-zA-Z\s_]*\}\}/g,
@@ -40,7 +40,7 @@ export class Feature {
 
 			parts.shift(); // Remove 'feature'
 
-			const interpreted = parts.reduce(
+			const interpreted: any = parts.reduce(
 				(carry, property) => {
 					return carry[property];
 				},

--- a/src/server/Node.ts
+++ b/src/server/Node.ts
@@ -163,15 +163,8 @@ export abstract class Node {
     return this.parameters.find((p) => p.name == name);
   }
 
-  getParameterValue(
-    name: string,
-    feature: Feature = null,
-  ): any {
-    const value = this.getParameter(name).value;
-
-    if (!feature) return value;
-
-    return this.interpretParameterValue(value, feature);
+  getParameterValue(name: string): any {
+    return this.getParameter(name).value;
   }
 
   public setParameterValue(name, value) {
@@ -179,40 +172,6 @@ export abstract class Node {
       (p) => p.name == name,
     );
     found.value = value;
-  }
-
-  protected interpretParameterValue(parametric, feature) {
-    /* eslint-disable no-useless-escape */
-    const matches = parametric.match(
-      /\{\{[\.a-zA-Z\s_]*\}\}/g,
-    );
-    if (matches) {
-      for (const match of matches) {
-        const originalMatch = match;
-
-        const parts = match
-          .replace('{{', '')
-          .replace('}}', '')
-          .trim()
-          .split('.');
-
-        parts.shift(); // Remove 'feature'
-
-        const interpreted = parts.reduce(
-          (carry, property) => {
-            return carry[property];
-          },
-          feature.original,
-        );
-
-        parametric = parametric.replace(
-          originalMatch,
-          interpreted,
-        );
-      }
-    }
-
-    return parametric;
   }
 
   protected input(portName = 'Input') {

--- a/src/server/nodes/CreateAttribute.ts
+++ b/src/server/nodes/CreateAttribute.ts
@@ -22,27 +22,18 @@ export class CreateAttribute extends Node {
       'Atrribute & value to create',
     );
 
-    const valuesMap = new Map();
+    const outputs = this.input().map((feature) => {
+			toCreate.forEach((row) => {
+				feature.set(
+					feature.parse(row['Attribute']['value']),
+					feature.parse(row['Value']['value'])
+				);
+			});
 
-    toCreate.map((result) => {
-      valuesMap.set(
-        result['Attribute']['value'],
-        result['Value']['value'],
-      );
+			return feature;
     });
 
-    this.output(
-      this.input().map((feature) => {
-        const { original } = feature;
-
-        let filtered = original;
-        for (const [attr, v] of valuesMap) {
-          filtered = Object.assign(filtered, { [attr]: v });
-        }
-
-        return new Feature(filtered);
-      }),
-    );
+		this.output(outputs);
 
     return diagramRunResult(this.diagram);
   }

--- a/src/server/nodes/HTTPRequest.ts
+++ b/src/server/nodes/HTTPRequest.ts
@@ -108,25 +108,25 @@ export class HTTPRequest extends Node {
     }
   }
 
-	protected verb(feature: Feature) {
+	protected verb(feature: Feature): string {
 		return feature.parse(
 			this.getParameterValue('verb')			
 		)
 	}
 
-	protected url(feature: Feature) {
+	protected url(feature: Feature): string {
 		return feature.parse(
 			this.getParameterValue('url')			
 		)		
 	}
 	
-	protected data(feature: Feature) {
+	protected data(feature: Feature): string {
 		return feature.parse(
 			this.getParameterValue('data')			
 		)		
 	}
 
-	protected config(feature: Feature) {
+	protected config(feature: Feature): string {
 		return feature.parse(
 			this.getParameterValue('config')			
 		)		

--- a/src/server/nodes/HTTPRequest.ts
+++ b/src/server/nodes/HTTPRequest.ts
@@ -85,26 +85,50 @@ export class HTTPRequest extends Node {
   }
 
   protected request(feature: Feature) {
-    if (this.getParameterValue('verb', feature) == 'GET') {
+    if (this.verb(feature) == 'GET') {
       return this.client.get(
-        this.getParameterValue('url', feature),
-        JSON.parse(this.getParameterValue('config')),
+        this.url(feature),
+        JSON.parse(this.config(feature)),
       );
     }
 
-    if (this.getParameterValue('verb') == 'POST') {
+    if (this.verb(feature) == 'POST') {
       return this.client.post(
-        this.getParameterValue('url', feature),
-        this.getParameterValue('data'),
-        JSON.parse(this.getParameterValue('config')),
+        this.url(feature),
+        this.data(feature),
+        JSON.parse(this.config(feature)),
       );
     }
 
-    if (this.getParameterValue('verb') == 'DELETE') {
+    if (this.verb(feature) == 'DELETE') {
       return this.client.delete(
-        this.getParameterValue('url', feature),
-        JSON.parse(this.getParameterValue('config')),
+        this.url(feature),
+        JSON.parse(this.config(feature)),
       );
     }
   }
+
+	protected verb(feature: Feature) {
+		return feature.parse(
+			this.getParameterValue('verb')			
+		)
+	}
+
+	protected url(feature: Feature) {
+		return feature.parse(
+			this.getParameterValue('url')			
+		)		
+	}
+	
+	protected data(feature: Feature) {
+		return feature.parse(
+			this.getParameterValue('data')			
+		)		
+	}
+
+	protected config(feature: Feature) {
+		return feature.parse(
+			this.getParameterValue('config')			
+		)		
+	}
 }

--- a/tests/Unit/Feature.test.ts
+++ b/tests/Unit/Feature.test.ts
@@ -23,3 +23,22 @@ test('it can get dot notated attributes', () => {
 
   expect(feature.get('user.name')).toBe('ajthinking');
 });
+
+
+test('it can parse template strings', () => {
+	const feature = new Feature({
+		name: 'Anders'
+	});
+
+	const greeting = "Hi {{ user.name }}!"
+
+	expect(feature.parse(greeting)).toBe('Hi Anders!');
+});
+
+test('it can parse non template strings', () => {
+	const feature = new Feature({});
+
+	const greeting = "Hi!"
+
+	expect(feature.parse(greeting)).toBe('Hi!');
+});

--- a/tests/Unit/server/nodes/CreateAttribute.test.ts
+++ b/tests/Unit/server/nodes/CreateAttribute.test.ts
@@ -17,18 +17,18 @@ it('can add a attribute value to an object feature', async () => {
     .finish();
 });
 
-it('can add a attribute with object value to an object feature', async () => {
+it('can add a attribute using a template syntax', async () => {
   await when(CreateAttribute)
-    .hasInput([{}])
+    .hasInput([{name: 'ajthinking'}])
     .and()
     .parameters({
       'Atrribute & value to create': [
         {
-          Attribute: { value: 'foo' },
-          Value: { value: {} },
+          Attribute: { value: 'greeting' },
+          Value: { value: "Hi {{ user.name }}!" },
         },
       ],
     })
-    .assertOutput([{ foo: {} }])
+    .assertOutput([{ name: 'ajthinking', greeting: 'Hi ajthinking!' }])
     .finish();
 });


### PR DESCRIPTION
* Fixes templating for a couple of nodes. 
* Moves templating implementation from Node to Feature.
* Syntax: `"Hi {{ ARBITRARY_ROOT_NAME.path.to.attribute.name }} and goodbye"`

### Example
If we want to make a parameter "templatable", make sure to pass it through `Feature.parse()`:
```ts
const template = this.getParameterValue('url') 

features.map(feature => {
  const url = feature.parse(template)
});
```

![image](https://user-images.githubusercontent.com/3457668/140647848-92a7bc40-f325-4df7-97c0-1effc4ee23ca.png)

![image](https://user-images.githubusercontent.com/3457668/140647861-44909efa-2e79-47c5-a8d1-c788473108ec.png)
